### PR TITLE
Add options parameter to Provider initialize

### DIFF
--- a/leaflet-providers-0.0.2.js
+++ b/leaflet-providers-0.0.2.js
@@ -2,7 +2,7 @@
   var providers = {};
 
   L.TileLayer.Provider = L.TileLayer.extend({
-    initialize: function (arg) {
+    initialize: function (arg, options) {
       var parts = arg.split('.');
 
       var providerName = parts[0];
@@ -37,7 +37,9 @@
             return providers[attributionName].options.attribution;
           });
       }
-      L.TileLayer.prototype.initialize.call(this, provider.url, provider.options);
+      // Compute final options combining provider options with any user overrides
+      var layer_opts = L.Util.extend({}, provider.options, options);
+      L.TileLayer.prototype.initialize.call(this, provider.url, layer_opts);
     }
   });
 


### PR DESCRIPTION
I wanted to pass opacity to layers I created with Provider. There was no support to do this because the user could not pass options that went through to underlying TileLayer constructed.

I added an optional second parameter that gets combined with the provider.options to pass to the TileLayer constructor.
