### PR TITLE
Replace attribution placeholders recursively

### DIFF
--- a/leaflet-providers.js
+++ b/leaflet-providers.js
@@ -31,14 +31,20 @@
 				provider.url = provider.url(parts.splice(1).join('.'));
 			}
 
-			// replace attribution placeholders with their values from toplevel provider attribution.
-			var attribution = provider.options.attribution;
-			if (attribution.indexOf('{attribution.') !== -1) {
-				provider.options.attribution = attribution.replace(/\{attribution.(\w*)\}/,
+			// replace attribution placeholders with their values from toplevel provider attribution,
+			// recursively
+			var attributionReplacer = function (attr) {
+				if (attr.indexOf('{attribution.') === -1) {
+					return attr;
+				}
+				return attr.replace(/\{attribution.(\w*)\}/,
 					function (match, attributionName) {
-						return providers[attributionName].options.attribution;
-					});
-			}
+						return attributionReplacer(providers[attributionName].options.attribution);
+					}
+				);
+			};
+			provider.options.attribution = attributionReplacer(provider.options.attribution);
+
 			// Compute final options combining provider options with any user overrides
 			var layerOpts = L.Util.extend({}, provider.options, options);
 			L.TileLayer.prototype.initialize.call(this, provider.url, layerOpts);


### PR DESCRIPTION
ThunderForest is referring to OpenCycleMap which in turn refers to OpenStreetMap, but the previous implementation did not allow nesting.

Fixed with this PR.
