### PR TITLE
Small fix for array splice, for ie 8.

### DIFF
--- a/leaflet-providers.js
+++ b/leaflet-providers.js
@@ -30,7 +30,7 @@
 					options: L.Util.extend({}, provider.options, variant.options)
 				};
 			} else if (typeof provider.url === 'function') {
-				provider.url = provider.url(parts.splice(1).join('.'));
+				provider.url = provider.url(parts.splice(1, parts.length - 1).join('.'));
 			}
 
 			// replace attribution placeholders with their values from toplevel provider attribution,


### PR DESCRIPTION
Array splice requires the second argument, if this isn't provided the url function will not work correctly in ie8. This results in a broken MapBox tile url for IE 8.
