### PR TITLE
Add minZoom and maxZoom to Nokia

### DIFF
--- a/leaflet-providers.js
+++ b/leaflet-providers.js
@@ -340,6 +340,8 @@
 				attribution:
 					'Map &copy; <a href="http://developer.here.com">Nokia</a>, Data &copy; NAVTEQ 2012',
 				subdomains: '1234',
+				minZoom: 0,
+				maxZoom: 20,
 				devID: 'xyz', //These basemaps are free and you can sign up here:  http://developer.here.com/plans
 				appID: 'abc'
 			},


### PR DESCRIPTION
I noticed that there was no maxZoom set for Nokia, which was giving me a small issue when changing between layers. This adds minZoom and maxZoom, which I got from the [info](https://developer.here.com/rest-apis/documentation/enterprise-map-tile/topics/resource-info.html) endpoints for each layer.
