### PR TITLE
Update HERE as requested by Marek

### DIFF
--- a/leaflet-providers.js
+++ b/leaflet-providers.js
@@ -316,7 +316,7 @@
 				'app_id={app_id}&app_code={app_code}',
 			options: {
 				attribution:
-					'Map &copy; <a href="http://developer.here.com">HERE</a>, Data &copy; NAVTEQ 2012',
+					'Map &copy; 1987-2014 <a href="http://developer.here.com">HERE</a>',
 				subdomains: '1234',
 				mapID: 'newest',
 				'app_id': '<insert your app_id here>',


### PR DESCRIPTION
HERE marketing guy just asked to remove the Navteq attribution:

> You have left still Navteq reference in the attribution. Could you please
> remove this as well. Just please leave
> "© 1987-2014 HERE"
