### PR TITLE
Simple test to check for valid url templates

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,13 +8,19 @@
     "url": "git://github.com/leaflet-extras/leaflet-providers.git"
   },
   "scripts": {
-    "test": "jshint leaflet-providers.js preview/*.js"
+    "test": "npm run lint && npm run testsuite",
+    "lint": "jshint leaflet-providers.js preview/*.js",
+    "testsuite": "node test/test.js | tspec"
   },
   "license": "BSD-2-Clause",
   "bugs": {
     "url": "https://github.com/leaflet-extras/leaflet-providers/issues"
   },
   "devDependencies": {
-    "jshint": "~2.1.11"
+    "jshint": "~2.1.11",
+    "tape": "~2.12.3",
+    "leaflet": "~0.7.2",
+    "tap-spec": "~0.1.9",
+    "leaflet-headless": "0.0.3"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -1,0 +1,60 @@
+var test = require('tape');
+
+var L = require('leaflet-headless');
+require('../leaflet-providers.js');
+
+// monkey-patch getTileUrl with fake values.
+L.TileLayer.prototype.getTileUrl = function (coords) {
+	return L.Util.template(this._url, L.extend({
+		r: '',
+		s: this._getSubdomain(coords),
+		x: coords.x,
+		y: coords.y,
+		z: 15
+	}, this.options));
+};
+
+function ignored(providerName) {
+	return providerName.indexOf('MapBox') !== -1;
+}
+
+function allLayers() {
+	var layers = [];
+
+	function addLayer(name) {
+		if (ignored(name)) {
+			return;
+		}
+
+		var layer = L.tileLayer.provider(name);
+		layer._name = name;
+
+		layers.push(layer);
+	}
+
+	for (var provider in L.TileLayer.Provider.providers) {
+		if (L.TileLayer.Provider.providers[provider].variants) {
+			for (var variant in L.TileLayer.Provider.providers[provider].variants) {
+				addLayer(provider + '.' + variant);
+			}
+		} else {
+			addLayer(provider);
+		}
+	}
+
+	return layers;
+}
+
+allLayers().forEach(function (layer) {
+	test('layer ' + layer._name, function (t) {
+		t.plan(2);
+
+		t.assert(layer instanceof L.TileLayer, 'layer is TileLayer');
+
+		t.doesNotThrow(function () {
+			// fake getTileUrl call
+			layer.getTileUrl({ x: 16369, y: 10896});
+		}, 'should not throw when creating url');
+
+	});
+});


### PR DESCRIPTION
This is a lighter version of #65, without phantomjs, which tests a faked `getTileUrl` call. 

If the url template contains placeholders not found in the options map, it will complain about missing variables, which is a basis provider validity check, without making real connections.

Not sure what else we can test without making actual HTTP calls to the tile providers...