### PR TITLE
fixed source generation for arrays and objects

### DIFF
--- a/preview/preview.js
+++ b/preview/preview.js
@@ -179,7 +179,8 @@
 							tileLayerCode += "'" + escapeHtml(options[option]) + "'";
 							//jshint quotmark:single
 						} else {
-							tileLayerCode += options[option];
+							/* global JSON:true */
+							tileLayerCode += JSON.stringify(options[option]);
 						}
 					}
 					tileLayerCode += '\n});\n';


### PR DESCRIPTION
fixed code preview (Plain JavaScript:) for settings with array values
this code:

``` js
{
  subdomain: ["t1","t2","t3","t4"]
}
```

was previously rendered as:

``` js
{
  subdomains: t1,t2,t3,t4,
}
```

this code is used in pull request #98
