### PR TITLE
proposal of shorter osm attribution

### DIFF
--- a/leaflet-providers.js
+++ b/leaflet-providers.js
@@ -72,8 +72,7 @@
 			url: 'http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
 			options: {
 				attribution:
-					'&copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, ' +
-					'<a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>'
+					'&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'
 			},
 			variants: {
 				Mapnik: {},


### PR DESCRIPTION
Based on http://wiki.openstreetmap.org/wiki/Legal_FAQ#3._Using recommendations :

Link to www.openstreetmap.org/copyright which is available in many languages

> Because OpenStreetMap is its contributors, you may omit the word "contributors" if space is limited. 

Allow to have shorten OSM attribution for tiles based on OSM and other sources.
