### PR TITLE
Adding NASA GIBS Imagery Products

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,8 +63,9 @@
 			'Esri NatGeoWorldMap': L.tileLayer.provider('Esri.NatGeoWorldMap'),
 			'Esri WorldGrayCanvas': L.tileLayer.provider('Esri.WorldGrayCanvas'),
 			'Acetate': L.tileLayer.provider('Acetate'),
-			'NASA MODIS Terra (Today)': L.tileLayer.provider('NASAGIBS.ModisTerraTrueColorCR'),
-			'NASA MODIS Aqua (Today)': L.tileLayer.provider('NASAGIBS.ModisAquaTrueColorCR')
+			'NASA MODIS Terra True Color (Today)': L.tileLayer.provider('NASAGIBS.ModisTerraTrueColorCR'),
+			'NASA MODIS Terra Bands 3-6-7 (Today)': L.tileLayer.provider('NASAGIBS.ModisTerraBands367CR'),
+			'NASA/NOAA VIIRS Earth at Night (2012)': L.tileLayer.provider('NASAGIBS.ViirsEarthAtNight2012')
 		};
 
 		var overlayLayers = {
@@ -80,8 +81,10 @@
 			'OpenWeatherMap Wind': L.tileLayer.provider('OpenWeatherMap.Wind'),
 			'OpenWeatherMap Temperature': L.tileLayer.provider('OpenWeatherMap.Temperature'),
 			'OpenWeatherMap Snow': L.tileLayer.provider('OpenWeatherMap.Snow'),
-			'NASA MODIS Terra LST (Today)': L.tileLayer.provider('NASAGIBS.ModisTerraLST'),
-			'NASA MODIS Aqua LST (Today)': L.tileLayer.provider('NASAGIBS.ModisAquaLST')
+			'NASA MODIS Terra LST (Today)': L.tileLayer.provider('NASAGIBS.ModisTerraLSTDay'),
+			'NASA MODIS Terra Snow Cover (Today)': L.tileLayer.provider('NASAGIBS.ModisTerraSnowCover'),
+			'NASA MODIS Terra Aerosol Optical Depth (Today)': L.tileLayer.provider('NASAGIBS.ModisTerraAOD'),
+			'NASA MODIS Terra Chlorophyll (Today)': L.tileLayer.provider('NASAGIBS.ModisTerraChlorophyll')
 		};
 
 		var layerControl = L.control.layers(baseLayers, overlayLayers, {collapsed: false}).addTo(map);

--- a/index.html
+++ b/index.html
@@ -62,7 +62,9 @@
 			'Esri OceanBasemap': L.tileLayer.provider('Esri.OceanBasemap'),
 			'Esri NatGeoWorldMap': L.tileLayer.provider('Esri.NatGeoWorldMap'),
 			'Esri WorldGrayCanvas': L.tileLayer.provider('Esri.WorldGrayCanvas'),
-			'Acetate': L.tileLayer.provider('Acetate')
+			'Acetate': L.tileLayer.provider('Acetate'),
+			'NASA MODIS Terra (Today)': L.tileLayer.provider('NASAGIBS.ModisTerraTrueColorCR'),
+			'NASA MODIS Aqua (Today)': L.tileLayer.provider('NASAGIBS.ModisAquaTrueColorCR')
 		};
 
 		var overlayLayers = {
@@ -77,7 +79,9 @@
 			'OpenWeatherMap PressureContour': L.tileLayer.provider('OpenWeatherMap.PressureContour'),
 			'OpenWeatherMap Wind': L.tileLayer.provider('OpenWeatherMap.Wind'),
 			'OpenWeatherMap Temperature': L.tileLayer.provider('OpenWeatherMap.Temperature'),
-			'OpenWeatherMap Snow': L.tileLayer.provider('OpenWeatherMap.Snow')
+			'OpenWeatherMap Snow': L.tileLayer.provider('OpenWeatherMap.Snow'),
+			'NASA MODIS Terra LST (Today)': L.tileLayer.provider('NASAGIBS.ModisTerraLST'),
+			'NASA MODIS Aqua LST (Today)': L.tileLayer.provider('NASAGIBS.ModisAquaLST')
 		};
 
 		var layerControl = L.control.layers(baseLayers, overlayLayers, {collapsed: false}).addTo(map);

--- a/leaflet-providers.js
+++ b/leaflet-providers.js
@@ -458,6 +458,52 @@
 			options: {
 				attribution: '{attribution.OpenStreetMap}'
 			}
+		},
+		NASAGIBS: {
+			url: 'http://map1.vis.earthdata.nasa.gov/wmts-webmerc/{variant}/default//{tilematrixset}/{z}/{y}/{x}.{format}',
+			options: {
+				attribution: 'NASA EOSDIS'
+			},
+			variants: {
+			    ModisTerraTrueColorCR: {
+					options: {
+						variant: 'MODIS_Terra_CorrectedReflectance_TrueColor',
+						tilematrixset: 'GoogleMapsCompatible_Level9',
+						format: 'jpg',
+						minZoom: 0,
+						maxZoom: 9
+					}
+				},
+			    ModisAquaTrueColorCR: {
+					options: {
+						variant: 'MODIS_Aqua_CorrectedReflectance_TrueColor',
+						tilematrixset: 'GoogleMapsCompatible_Level9',
+						format: 'jpg',
+						minZoom: 0,
+						maxZoom: 9
+					}
+				},
+			    ModisTerraLST: {
+					options: {
+						variant: 'MODIS_Terra_Land_Surface_Temp_Day',
+						tilematrixset: 'GoogleMapsCompatible_Level7',
+						format: 'png',
+						minZoom: 0,
+						maxZoom: 7,
+						opacity: 0.5
+					}
+				},
+			    ModisAquaLST: {
+					options: {
+						variant: 'MODIS_Aqua_Land_Surface_Temp_Day',
+						tilematrixset: 'GoogleMapsCompatible_Level7',
+						format: 'png',
+						minZoom: 0,
+						maxZoom: 7,
+						opacity: 0.5
+					}
+				}
+			}
 		}
 	};
 

--- a/leaflet-providers.js
+++ b/leaflet-providers.js
@@ -462,7 +462,7 @@
 		NASAGIBS: {
 			url: 'http://map1.vis.earthdata.nasa.gov/wmts-webmerc/{variant}/default//{tilematrixset}/{z}/{y}/{x}.{format}',
 			options: {
-				attribution: 'NASA EOSDIS'
+				attribution: 'Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (ESDIS, https://earthdata.nasa.gov) with funding provided by NASA/HQ.'
 			},
 			variants: {
 			    ModisTerraTrueColorCR: {

--- a/leaflet-providers.js
+++ b/leaflet-providers.js
@@ -474,35 +474,64 @@
 						maxZoom: 9
 					}
 				},
-			    ModisAquaTrueColorCR: {
+			    ModisTerraBands367CR: {
 					options: {
-						variant: 'MODIS_Aqua_CorrectedReflectance_TrueColor',
+						variant: 'MODIS_Terra_CorrectedReflectance_Bands367',
 						tilematrixset: 'GoogleMapsCompatible_Level9',
 						format: 'jpg',
 						minZoom: 0,
 						maxZoom: 9
 					}
 				},
-			    ModisTerraLST: {
+			    ViirsEarthAtNight2012: {
+					options: {
+						variant: 'VIIRS_CityLights_2012',
+						tilematrixset: 'GoogleMapsCompatible_Level8',
+						format: 'jpg',
+						minZoom: 0,
+						maxZoom: 8
+					}
+				},
+			    ModisTerraLSTDay: {
 					options: {
 						variant: 'MODIS_Terra_Land_Surface_Temp_Day',
 						tilematrixset: 'GoogleMapsCompatible_Level7',
 						format: 'png',
 						minZoom: 0,
 						maxZoom: 7,
-						opacity: 0.5
+						opacity: 0.75
 					}
 				},
-			    ModisAquaLST: {
+			    ModisTerraSnowCover: {
 					options: {
-						variant: 'MODIS_Aqua_Land_Surface_Temp_Day',
+						variant: 'MODIS_Terra_Snow_Cover',
+						tilematrixset: 'GoogleMapsCompatible_Level8',
+						format: 'png',
+						minZoom: 0,
+						maxZoom: 8,
+						opacity: 0.75
+					}
+				},
+			    ModisTerraAOD: {
+					options: {
+						variant: 'MODIS_Terra_Aerosol',
+						tilematrixset: 'GoogleMapsCompatible_Level6',
+						format: 'png',
+						minZoom: 0,
+						maxZoom: 6,
+						opacity: 0.75
+					}
+				},
+			    ModisTerraChlorophyll: {
+					options: {
+						variant: 'MODIS_Terra_Chlorophyll_A',
 						tilematrixset: 'GoogleMapsCompatible_Level7',
 						format: 'png',
 						minZoom: 0,
 						maxZoom: 7,
-						opacity: 0.5
+						opacity: 0.75
 					}
-				}
+				}				
 			}
 		}
 	};


### PR DESCRIPTION
Adding a sample of NASA imagery layers available through the Global Imagery Browse Services (GIBS) project.  These products are "Near Real-Time" in that the imagery shown was available within 3 hours of observation. The imagery is updated throughout the day as new products are received. GIBS has historical imagery as well, but only "today" is added as a sample.