### PR TITLE
Use example API keys in https test, enable MapBox/HERE https

### DIFF
--- a/leaflet-providers.js
+++ b/leaflet-providers.js
@@ -175,7 +175,7 @@
 		},
 		MapBox: {
 			url: function (id) {
-				return 'http://{s}.tiles.mapbox.com/v3/' + id + '/{z}/{x}/{y}.png';
+				return '//{s}.tiles.mapbox.com/v3/' + id + '/{z}/{x}/{y}.png';
 			},
 			options: {
 				attribution:
@@ -341,7 +341,7 @@
 			 * envirionments.
 			 */
 			url:
-				'http://{s}.{base}.maps.cit.api.here.com/maptile/2.1/' +
+				'//{s}.{base}.maps.cit.api.here.com/maptile/2.1/' +
 				'maptile/{mapID}/{variant}/{z}/{x}/{y}/256/png8?' +
 				'app_id={app_id}&app_code={app_code}',
 			options: {

--- a/preview/https-support.js
+++ b/preview/https-support.js
@@ -11,7 +11,7 @@ var container = L.DomUtil.get('maps');
 function addLayer(provider) {
 	var layer = L.tileLayer.provider(provider);
 	var url = layer._url.replace('{variant}', layer.options.variant);
-	var options = layer.options;
+	var options = L.extend({}, layer.options, layer._options);
 
 	if (url.indexOf('http:') === 0) {
 		url = url.slice(5);
@@ -55,12 +55,4 @@ function addLayer(provider) {
 	});
 }
 
-for (var provider in L.TileLayer.Provider.providers) {
-	if (L.TileLayer.Provider.providers[provider].variants) {
-		for (var variant in L.TileLayer.Provider.providers[provider].variants) {
-			addLayer(provider + '.' + variant);
-		}
-	} else {
-		addLayer(provider);
-	}
-}
+L.tileLayer.provider.eachLayer(addLayer);

--- a/preview/index.html
+++ b/preview/index.html
@@ -85,6 +85,7 @@
 
 	<script src="highlightjs/highlight.pack.js"></script>
 
+	<script src="shared.js"></script>
 	<script src="preview.js"></script>
 </body>
 </html>

--- a/preview/shared.js
+++ b/preview/shared.js
@@ -1,0 +1,51 @@
+// This is a list of example API codes, to make this preview
+// functioning. Please register with the providers to use them
+// with your own app.
+var exampleAPIcodes = {
+	'HERE': {
+		'app_id': 'Y8m9dK2brESDPGJPdrvs',
+		'app_code': 'dq2MYIvjAotR8tHvY8Q_Dg'
+	},
+	'MapBox': 'MapBox.examples.map-i86nkdio'
+};
+
+var origProviderInit = L.TileLayer.Provider.prototype.initialize;
+L.TileLayer.Provider.include({
+	initialize: function (providerName, options) {
+		this._providerName = providerName;
+		options = options || {};
+
+		// replace example API codes in options
+		if (this._providerName === 'MapBox') {
+			providerName = exampleAPIcodes.MapBox;
+			this._exampleUrl = L.TileLayer.Provider.providers.MapBox.url('MapBox.\' + your_api_code + \'');
+		} else {
+			var provider = this._providerName.split('.')[0];
+			if (provider in exampleAPIcodes) {
+				L.extend(options, exampleAPIcodes[provider]);
+			}
+		}
+		origProviderInit.call(this, providerName, options);
+	}
+});
+
+// save the options while creating tilelayers to cleanly access them later.
+var origTileLayerInit = L.TileLayer.prototype.initialize;
+L.TileLayer.include({
+	initialize: function (url, options) {
+		this._options = options;
+		origTileLayerInit.apply(this, arguments);
+	}
+});
+
+L.tileLayer.provider.eachLayer = function (callback) {
+	for (var provider in L.TileLayer.Provider.providers) {
+		if (L.TileLayer.Provider.providers[provider].variants) {
+			for (var variant in L.TileLayer.Provider.providers[provider].variants) {
+				callback(provider + '.' + variant);
+			}
+		} else {
+			callback(provider);
+		}
+	}
+};

--- a/preview/test-https-support.html
+++ b/preview/test-https-support.html
@@ -63,6 +63,7 @@
 	<script src="http://cdn.leafletjs.com/leaflet-0.7.3/leaflet-src.js"></script>
 	<script src="../leaflet-providers.js"></script>
 
+	<script src="shared.js"></script>
 	<script src="https-support.js"></script>
 </body>
 </html>


### PR DESCRIPTION
This pull:
 - enables the use of example API keys in the https test page
 - adds MapBox example url to preview (does not give example source code with MapBox api key, just `your_api_code`,
 - enables https for HERE and MapBox

@tmcw Can you comment on if we may use [this example API code](https://github.com/leaflet-extras/leaflet-providers/blob/ea7a6860c1cfda22ba3bb1308b2c2940360c227d/preview/shared.js#L9) like this:
![mapbox-preview](https://cloud.githubusercontent.com/assets/1470389/6503154/9a2b5e26-c32a-11e4-84eb-88a428f3cc7d.png)