### PR TITLE
Leaflet is not a dependency in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,6 +3,9 @@
   "version": "1.0.23",
   "homepage": "https://github.com/leaflet-extras/leaflet-providers",
   "description": "An extension to Leaflet that contains configurations for various free tile providers.",
+  "dependencies": {
+    "leaflet": "~0.7.3"
+  },
   "main": "leaflet-providers.js",
   "keywords": [
     "leaflet",


### PR DESCRIPTION
I think that leaflet should be a dependency in the `bower.json` (possibly also `package.json`). I am currently having issues with build ordering using brunch. leaflet-providers are loaded before the leaflet package. This patch fixes this.