### PR TITLE
Final https touches

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,12 @@ In addition to the providers you are free to use, we support some layers which r
 
 ### HERE (formerly Nokia).
 
-In order to use HERE basemaps, you must [register](http://developer.here.com/get-started). With your `app_id` and `app_code` specified in the options. For example:
+In order to use HERE layers, you must [register](http://developer.here.com/). Once registered, you can create an `app_id` and `app_code` which you have to pass to `L.tileLayer.provider` in the options:
 
 ```Javascript
 L.tileLayer.provider('HERE.terrainDay', {
-    app_id: 'insert ID here',
-    app_code: 'insert ID here'
+    app_id: '<insert ID here>',
+    app_code: '<insert ID here>'
 }).addTo(map);
 ```
 
@@ -38,14 +38,14 @@ L.tileLayer.provider('HERE.terrainDay', {
 
 ### Mapbox
 
-In order to use Mapbox maps, you must [register](https://tiles.mapbox.com/signup). If your user name is `YourName` and your map is called `MyMap` you can add it with
+In order to use Mapbox maps, you must [register](https://tiles.mapbox.com/signup). If your user name is `YourName` and your map is called `MyMap` you can add it with:
 ```JavaScript
 L.tileLayer.provider('MapBox.YourName.MyMap');
 ```
 
 ### Esri/ArcGIS
 
-In order to use ArcGIS maps, you must [register](https://developers.arcgis.com/en/sign-up/) and abide by the [terms of service](https://developers.arcgis.com/en/terms/).
+In order to use ArcGIS maps, you must [register](https://developers.arcgis.com/en/sign-up/) and abide by the [terms of service](https://developers.arcgis.com/en/terms/). No special syntax is required.
 
 [Available Esri layers](http://leaflet-extras.github.io/leaflet-providers/preview/#filter=Esri)
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ Leaflet-providers [providers](#providers) are refered to with a `provider[.<vari
 L.tileLayer.provider('Stamen.Watercolor').addTo(map);
 ```
 
+## Protocol relativity (`https://`-urls)
+
+Leaflet-providers tries to use `https://` if the page uses `https://` and the provider supports it.
+You can force the use of `http://` by passing `force_http: true` in the options argument.
+
 # Providers
 
 Leaflet-providers provides tile layers from different providers, including *OpenStreetMap*, *MapQuestOpen*, *Stamen*, *Esri* and *OpenWeatherMap*. The full listing of free to use layers can be [previewed](http://leaflet-extras.github.io/leaflet-providers/preview/index.html). The page will show you the name to use with `leaflet-providers.js` and the code to use it without dependencies.
@@ -20,15 +25,16 @@ In addition to the providers you are free to use, we support some layers which r
 
 ### HERE (formerly Nokia).
 
-In order to use HERE basemaps, you must [register](http://developer.here.com/get-started). With your `app_id` and `app_code` specified in the options. [Available HERE layers](http://leaflet-extras.github.io/leaflet-providers/preview/#filter=HERE)
+In order to use HERE basemaps, you must [register](http://developer.here.com/get-started). With your `app_id` and `app_code` specified in the options. For example:
 
-For example:
 ```Javascript
 L.tileLayer.provider('HERE.terrainDay', {
     app_id: 'insert ID here',
     app_code: 'insert ID here'
 }).addTo(map);
 ```
+
+[Available HERE layers](http://leaflet-extras.github.io/leaflet-providers/preview/#filter=HERE)
 
 ### Mapbox
 
@@ -39,18 +45,9 @@ L.tileLayer.provider('MapBox.YourName.MyMap');
 
 ### Esri/ArcGIS
 
-In order to use ArcGIS maps, you must [register](https://developers.arcgis.com/en/sign-up/) and abide by the [terms of service](https://developers.arcgis.com/en/terms/). [Available Esri layers](http://leaflet-extras.github.io/leaflet-providers/preview/#filter=Esri):
+In order to use ArcGIS maps, you must [register](https://developers.arcgis.com/en/sign-up/) and abide by the [terms of service](https://developers.arcgis.com/en/terms/).
 
-* Esri.WorldStreetMap
-* Esri.DeLorme
-* Esri.WorldTopoMap
-* Esri.WorldImagery
-* Esri.WorldTerrain
-* Esri.WorldShadedRelief
-* Esri.WorldPhysical
-* Esri.OceanBasemap
-* Esri.NatGeoWorldMap
-* Esri.WorldGrayCanvas
+[Available Esri layers](http://leaflet-extras.github.io/leaflet-providers/preview/#filter=Esri)
 
 # Attribution
 

--- a/leaflet-providers.js
+++ b/leaflet-providers.js
@@ -154,6 +154,10 @@
 			}
 		},
 		MapQuestOpen: {
+			/* Mapquest does support https, but with a different subdomain:
+			 * https://otile{s}-s.mqcdn.com/tiles/1.0.0/{type}/{z}/{x}/{y}.{ext}
+			 * which makes implementing protocol relativity impossible.
+			 */
 			url: 'http://otile{s}.mqcdn.com/tiles/1.0.0/{type}/{z}/{x}/{y}.{ext}',
 			options: {
 				type: 'map',


### PR DESCRIPTION
- Add a note about https support for MapQuest in code (sort of fixes #116).
- Document protocol relativity in README.md.
- Remove list of ESRI variants + let preview link stand out a little more.
