### PR TITLE
Only include useful files in the npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,12 @@
   "bugs": {
     "url": "https://github.com/leaflet-extras/leaflet-providers/issues"
   },
+  "files": [
+      "leaflet-providers.js",
+      "README.md",
+      "CHANGELOG.md",
+      "licence.md"
+  ],
   "devDependencies": {
     "chai": "^2.3.0",
     "eslint": "^1.1.0",


### PR DESCRIPTION
With the last release, I occidentally included a temporary file in the npm package. This should make sure only the interesting files get included, keeping the package small.