### PR TITLE
Added new variants to HERE and made the URL more dynamic.

### DIFF
--- a/leaflet-providers.js
+++ b/leaflet-providers.js
@@ -422,8 +422,8 @@
 			 */
 			url:
 				'//{s}.{base}.maps.cit.api.here.com/maptile/2.1/' +
-				'maptile/{mapID}/{variant}/{z}/{x}/{y}/256/png8?' +
-				'app_id={app_id}&app_code={app_code}',
+				'{type}/{mapID}/{variant}/{z}/{x}/{y}/{size}/{format}?' +
+				'app_id={app_id}&app_code={app_code}&lg={language}',
 			options: {
 				attribution:
 					'Map &copy; 1987-2014 <a href="http://developer.here.com">HERE</a>',
@@ -433,7 +433,11 @@
 				'app_code': '<insert your app_code here>',
 				base: 'base',
 				variant: 'normal.day',
-				maxZoom: 20
+				maxZoom: 20,
+				type: 'maptile',
+				language: 'eng',
+				format: 'png8',
+				size: '256'
 			},
 			variants: {
 				normalDay: 'normal.day',
@@ -448,6 +452,23 @@
 				normalNightGrey: 'normal.night.grey',
 				normalNightGreyMobile: 'normal.night.grey.mobile',
 
+				basicMap: {
+					options: {
+						type: 'basetile'
+					}
+				},
+				mapLabels: {
+					options: {
+						type: 'labeltile',
+						format: 'png'
+					}
+				},
+				trafficFlow: {
+					options: {
+						base: 'traffic',
+						type: 'flowtile'
+					}
+				},
 				carnavDayGrey: 'carnav.day.grey',
 				hybridDay: {
 					options: {


### PR DESCRIPTION
In my project i need to:

* Split HERE into different layers to be able to toggle trafficflow on/off.
* Select language for the label layer.
* Prioritize each layer so trafficflow does not cover labels.

Thought others might want to do the same thing, in any case the URL for HERE is now more dynamic and I've added a couple of variants to get layers of the map rather than an entire map.