### PR TITLE
Remove NLS layers which are not supposed to be freely used

### DIFF
--- a/leaflet-providers.js
+++ b/leaflet-providers.js
@@ -664,54 +664,18 @@
 			// NLS maps are copyright National library of Scotland.
 			// http://maps.nls.uk/projects/api/index.html
 			// Please contact NLS for anything other than non-commercial low volume usage
-			url: '//nls-{s}.tileserver.com/{variant}/{z}/{x}/{y}.jpg',
+			//
+			// Map sources: Ordnance Survey 1:1m to 1:63K, 1920s-1940s
+			//   z0-9  - 1:1m
+			//  z10-11 - quarter inch (1:253440)
+			//  z12-18 - one inch (1:63360)
+			url: '//nls-{s}.tileserver.com/nls/{z}/{x}/{y}.jpg',
 			options: {
 				attribution: '<a href="http://geo.nls.uk/maps/">National Library of Scotland Historic Maps</a>',
 				bounds: [[49.6, -12], [61.7, 3]],
 				minZoom: 1,
 				maxZoom: 18,
 				subdomains: '0123',
-			},
-			variants: {
-				// OS 1:1m to 1:63K, 1920s-1940s
-				//   z0-9  - 1:1m
-				//  z10-11 - quarter inch (1:253440)
-				//  z12-18 - one inch (1:63360)
-				'OS_1920': 'nls',
-				'OS_opendata': {
-					url: 'http://geo.nls.uk/maps/opendata/{z}/{x}/{y}.png',
-					options: {
-						maxZoom: 16
-					}
-				},
-				// OS six inch, 1843 - 1882
-				'OS_6inch_1st': {
-					url: 'http://geo.nls.uk/maps/os/six_inch/{z}/{x}/{y}.png',
-					options: {
-						tms: true,
-						minZoom: 6,
-						maxZoom: 16,
-						bounds: [[49.86261, -8.66444], [60.89421, 1.7785]]
-					}
-				},
-				// OS one inch, 1945 - 1947
-				'OS_npe': {
-					url: 'http://geo.nls.uk/maps/os/newpopular/{z}/{x}/{y}.png',
-					options: {
-						tms: true,
-						minZoom: 3,
-						maxZoom: 15
-					}
-				},
-				'GSGS_Ireland': {
-					url: 'http://geo.nls.uk/maps/ireland/gsgs4136/{z}/{x}/{y}.png',
-					options: {
-						tms: true,
-						minZoom: 5,
-						maxZoom: 15,
-						bounds: [[51.371780, -10.810546], [55.422779, -5.262451]]
-					}
-				}
 			}
 		}
 	};

--- a/leaflet-providers.js
+++ b/leaflet-providers.js
@@ -661,7 +661,9 @@
 			}
 		},
 		NLS: {
-			// Maps from http://maps.nls.uk/geo/explore/
+			// NLS maps are copyright National library of Scotland.
+			// http://maps.nls.uk/projects/api/index.html
+			// Please contact NLS for anything other than non-commercial low volume usage
 			url: '//nls-{s}.tileserver.com/{variant}/{z}/{x}/{y}.jpg',
 			options: {
 				attribution: '<a href="http://geo.nls.uk/maps/">National Library of Scotland Historic Maps</a>',
@@ -671,12 +673,6 @@
 				subdomains: '0123',
 			},
 			variants: {
-				// OS 1:1m to 1:10K, 1900s
-				//   z0-10 - 1:1m
-				//  z11-12 - ?
-				//  z13-14 - one inch (1:63360)
-				//  z15-18 - six inch (1:10560)
-				'OS_1900': 'NLS_API',
 				// OS 1:1m to 1:63K, 1920s-1940s
 				//   z0-9  - 1:1m
 				//  z10-11 - quarter inch (1:253440)
@@ -698,10 +694,6 @@
 						bounds: [[49.86261, -8.66444], [60.89421, 1.7785]]
 					}
 				},
-				// OS six inch, 1888 - 1913
-				'OS_6inch': 'os_6_inch_gb',
-				// OS 1:25000, 1937 - 1961
-				'OS_25k': '25k',
 				// OS one inch, 1945 - 1947
 				'OS_npe': {
 					url: 'http://geo.nls.uk/maps/os/newpopular/{z}/{x}/{y}.png',
@@ -709,16 +701,6 @@
 						tms: true,
 						minZoom: 3,
 						maxZoom: 15
-					}
-				},
-				// OS one inch, 1952 - 1961
-				'OS_7th': 'os7gb',
-				// OS 1:1056, 1893 - 1896
-				'OS_London': {
-					options: {
-						variant: 'London_1056',
-						minZoom: 9,
-						bounds: [[51.177621, -0.708618], [51.618016, 0.355682]]
 					}
 				},
 				'GSGS_Ireland': {


### PR DESCRIPTION
This is my first try at fixing #178. NLS replied and I will ask them if this diff satisfies their concerns enough. Quoting the email:
> NLS.OS_1900
> NLS.OS_6inch
> NLS.OS_25k
> NLS.OS_7th
> NLS.OS_London
> 
> These layers should not be made available within leaflet-providers and we would be grateful if you would remove them.
