### PR TITLE
Refactoring, https

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -11,6 +11,7 @@
     "space-before-blocks": 2,
     "space-after-keywords": 2,
     "no-lonely-if": 2,
+    "eqeqeq": 2,
     "comma-style": 2,
     "no-underscore-dangle": 0,
     "no-constant-condition": 0,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,11 @@
 # Leaflet-providers changelog
 
 ## master version
+ - Added https support for MapQuest and CartoDB #<TODO>, (fixes #189)
 
 ## 1.1.6 (2015-11-03)
  - Removed most of the NLS layers per NLS request #193, fixes #178
- - Adde new variants to the HERE provider #183 by [@andreaswc](https://github.com/andreaswc)
+ - Added new variants to the HERE provider #183 by [@andreaswc](https://github.com/andreaswc)
  - Added some tests to make sure all the placeholders in the url template are replaced #188
 
 ## 1.1.5 (2015-10-01)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ L.tileLayer.provider('Stamen.Watercolor').addTo(map);
 ## Protocol relativity (`https://`-urls)
 
 Leaflet-providers tries to use `https://` if the page uses `https://` and the provider supports it.
-You can force the use of `http://` by passing `force_http: true` in the options argument.
+You can force the use of `http://` by passing `forceHTTP: true` in the options argument.
 
 ## Retina tiles
 

--- a/leaflet-providers.js
+++ b/leaflet-providers.js
@@ -59,7 +59,7 @@
 				options = L.Util.extend({}, options, variantOptions(provider, variant));
 			}
 
-			var forceHTTP = (window.location.protocol == 'file:') || optionsArg.forceHTTP;
+			var forceHTTP = (window.location.protocol === 'file:') || optionsArg.forceHTTP;
 			if (url.indexOf('//') === 0 && forceHTTP) {
 				url = 'http:' + url;
 			} else if (window.location.protocol == 'https:' && !forceHTTP) {

--- a/leaflet-providers.js
+++ b/leaflet-providers.js
@@ -62,7 +62,7 @@
 			var forceHTTP = (window.location.protocol === 'file:') || optionsArg.forceHTTP;
 			if (url.indexOf('//') === 0 && forceHTTP) {
 				url = 'http:' + url;
-			} else if (window.location.protocol == 'https:' && !forceHTTP) {
+			} else if (window.location.protocol === 'https:' && !forceHTTP) {
 				// If https_url is in provider, use that.
 				url = providers[provider]['https_url'] || url;
 			}

--- a/tests/test.js
+++ b/tests/test.js
@@ -56,6 +56,21 @@ describe('leaflet-providers', function () {
 		});
 	});
 
+	describe('Nonexistant providers', function () {
+		it('should fail for non-existant providers', function () {
+			var fn = function () {
+				L.tileLayer.provider('Example');
+			};
+			fn.should.throw('No such provider (Example)');
+		});
+		it('should fail for non-existant variants of existing providers', function () {
+			var fn = function () {
+				L.tileLayer.provider('OpenStreetMap.Example');
+			};
+			fn.should.throw('No such variant of OpenStreetMap (Example)');
+		});
+	});
+
 	describe('Each layer', function () {
 		L.tileLayer.provider.eachLayer(function (name) {
 			describe(name, function () {

--- a/tests/test.js
+++ b/tests/test.js
@@ -86,7 +86,7 @@ describe('leaflet-providers', function () {
 
 				it('should have valid options', function () {
 					for (var key in layer.options) {
-						if (validTileLayerOptions.indexOf(key) != -1) {
+						if (validTileLayerOptions.indexOf(key) !== -1) {
 							continue;
 						}
 						var placeholder = '{' + key + '}';


### PR DESCRIPTION
- Add https support for layers with different urls for https (MapQuest, CartoDB) (fixes #189)
- Add tests for non-existant provider or provider variants
- Try to refactor for clarity a bit. Not sure if I'm happy with it though.
- Removed the case an url is a function (Not used anymore after MapBox is removed 66566b8465a2c2fd32c4bd44590021bbfd3c3032)

Note that I'm not really sure if my approach with the https urls works like we want. What if a variant defines another URL which has proper protocol relativity? Then this will fail. It should work for the current layers though.