### PR TITLE
Bump leaflet to 1.0.0-rc.1, update eslint, lint inline js

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,7 +9,7 @@
     "array-bracket-spacing": 2,
     "computed-property-spacing": 2,
     "space-before-blocks": 2,
-    "space-after-keywords": 2,
+    "keyword-spacing": 2,
     "no-lonely-if": 2,
     "comma-style": 2,
     "no-underscore-dangle": 0,
@@ -26,6 +26,12 @@
     "module": false,
     "define": false,
     "require": true
+  },
+  "plugins": [
+    "html"
+  ],
+  "settings": {
+    "html/report-bad-indent": 2
   },
   "env": {
     "browser": true

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 	<!-- Leaflet style. REQUIRED! -->
-	<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.3/leaflet.css" />
+	<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/leaflet/1.0.0-rc.1/leaflet.css" />
 	<style>
 		html { height: 100% }
 		body { height: 100%; margin: 0; padding: 0;}
@@ -26,7 +26,7 @@
 	</div>
 	<div id="map" class="map"></div>
 
-	<script src="//cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.3/leaflet.js"></script>
+	<script src="//cdnjs.cloudflare.com/ajax/libs/leaflet/1.0.0-rc.1/leaflet.js"></script>
 	<script src="leaflet-providers.js"></script>
 	<script>
 		var map = L.map('map', {
@@ -79,10 +79,10 @@
 			'OpenWeatherMap Snow': L.tileLayer.provider('OpenWeatherMap.Snow')
 		};
 
-		var layerControl = L.control.layers(baseLayers, overlayLayers, {collapsed: false}).addTo(map);
+		L.control.layers(baseLayers, overlayLayers, {collapsed: false}).addTo(map);
 
 		// resize layers control to fit into view.
-		function resizeLayerControl() {
+		function resizeLayerControl () {
 			var layerControlHeight = document.body.clientHeight - (10 + 50);
 			var layerControl = document.getElementsByClassName('leaflet-control-layers-expanded')[0];
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "test": "npm run lint && npm run testsuite",
     "testsuite": "mocha-phantomjs tests/index.html",
-    "lint": "eslint --config .eslintrc leaflet-providers.js preview/*.js tests/test.js",
+    "lint": "eslint --config .eslintrc leaflet-providers.js index.html preview/*.js preview/*.html tests/*",
     "min": "uglifyjs leaflet-providers.js -mc -o leaflet-providers.min.js",
     "release": "mversion patch -m"
   },
@@ -26,7 +26,8 @@
   ],
   "devDependencies": {
     "chai": "^2.3.0",
-    "eslint": "^1.1.0",
+    "eslint": "^2.7.0",
+    "eslint-plugin-html": "^1.4.0",
     "mocha": "^2.2.4",
     "mocha-phantomjs": "^3.5.3",
     "mversion": "^1.3.0",

--- a/preview/https-support.js
+++ b/preview/https-support.js
@@ -1,15 +1,18 @@
 L.TileLayer.prototype._tileOnError = function () {
-	var layer = this._layer;
-	if (layer.errorContainer) {
-		layer.errorContainer.innerHTML = '<span class="fail">seems to be not supported</span>';
+	if (this.errorContainer) {
+		this.errorContainer.innerHTML = '<span class="fail">seems to be not supported</span>';
 	}
-};
+}
 
-var table = L.DomUtil.get('table');
+
 var container = L.DomUtil.get('maps');
 
 function addLayer (provider) {
 	var layer = L.tileLayer.provider(provider);
+
+	var httpsSupported = layer._url.indexOf('//') === 0;
+	var table = L.DomUtil.get('table-' + (httpsSupported ? 'supported' : 'unknown'));
+
 	var url = layer._url.replace('{variant}', layer.options.variant);
 	var options = L.extend({}, layer.options, layer._options);
 
@@ -22,17 +25,14 @@ function addLayer (provider) {
 	var row = L.DomUtil.create('tr', '', table);
 	L.DomUtil.create('td', '', row).innerHTML = provider;
 	var result = L.DomUtil.create('td', '', row);
-
-	if (layer._url.indexOf('//') === 0) {
-		result.innerHTML = '<span class="ok">☑ Supported</span>';
-	} else {
-		var but = L.DomUtil.create('button', '', result);
-		but.innerHTML = 'test...';
+	L.DomUtil.create('button', '', result).innerHTML = 'test...';
+	if (httpsSupported) {
+		result.innerHTML = '<span class="ok">☑</span> ' + result.innerHTML;
 	}
 
 	L.DomEvent.on(result, 'click', function () {
 		var center = [52, 4];
-		if ('bounds' in options) {
+		if ('bounds' in options && options.bounds) {
 			center = L.latLngBounds(options.bounds).getCenter();
 		}
 		result.innerHTML = 'testing...';
@@ -44,9 +44,8 @@ function addLayer (provider) {
 
 		L.DomUtil.create('h2', '', container).innerHTML = provider + ' (https):';
 		var map2 = L.map(L.DomUtil.create('div', 'map', container)).setView(center, 9);
-		var httpsLayer = L.tileLayer('https:' + url, options);
 
-		map2.addLayer(httpsLayer);
+		var httpsLayer = L.tileLayer('https:' + url, options).addTo(map2);
 
 		httpsLayer.errorContainer = result;
 		httpsLayer.on('load', function () {

--- a/preview/index.html
+++ b/preview/index.html
@@ -6,7 +6,7 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 
-	<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.5/leaflet.css" />
+	<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/leaflet/1.0.0-rc.1/leaflet.css" />
 
 	<style>
 		html {
@@ -77,7 +77,7 @@
 	</div>
 	<div id="map" class="map"></div>
 
-	<script src="//cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.5/leaflet-src.js"></script>
+	<script src="//cdnjs.cloudflare.com/ajax/libs/leaflet/1.0.0-rc.1/leaflet-src.js"></script>
 	<script src="../leaflet-providers.js"></script>
 
 	<script src="vendor/L.Control.Layers.Minimap.js"></script>

--- a/preview/test-bounds.html
+++ b/preview/test-bounds.html
@@ -6,7 +6,7 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 
-	<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.5/leaflet.css" />
+	<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/leaflet/1.0.0-rc.1/leaflet.css" />
 	<link rel="stylesheet" href="vendor/leaflet.draw.css" />
 
 	<style>
@@ -77,7 +77,7 @@
 	</div>
 	<div id="maps"></div>
 
-	<script src="//cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.5/leaflet-src.js"></script>
+	<script src="//cdnjs.cloudflare.com/ajax/libs/leaflet/1.0.0-rc.1/leaflet-src.js"></script>
 	<script src="../leaflet-providers.js"></script>
 	<script src="vendor/leaflet.draw-src.js"></script>
 

--- a/preview/test-https-support.html
+++ b/preview/test-https-support.html
@@ -17,10 +17,11 @@
 			vertical-align: baseline;
 			font: 14px/16px Arial, Helvetica, sans-serif;
 		}
-		#table {
-			width: 60%;
+		.container {
+			float: left;
+			width: 400px;
 		}
-		#table th {
+		table th {
 			text-align: left;
 		}
 		#maps {
@@ -54,9 +55,19 @@
 	</div>
 
 	<h1>Testing provider protocols</h1>
-	<table id="table">
-		<tr><th>Provider</th><th>HTTPS</th></tr>
-	</table>
+	<div class="container">
+		<h2>Known https support:</h2>
+		<table id="table-supported">
+			<tr><th>Provider</th><th>HTTPS</th></tr>
+		</table>
+	</div>
+
+	<div class="container">
+		<h2>Unknown https support:</h2>
+		<table id="table-unknown">
+			<tr><th>Provider</th><th>HTTPS</th></tr>
+		</table>
+	</div>
 	<div id="maps"></div>
 
 	<script src="//cdnjs.cloudflare.com/ajax/libs/leaflet/1.0.0-rc.1/leaflet-src.js"></script>

--- a/preview/test-https-support.html
+++ b/preview/test-https-support.html
@@ -6,7 +6,7 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 
-	<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.5/leaflet.css" />
+	<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/leaflet/1.0.0-rc.1/leaflet.css" />
 
 	<style>
 		html {
@@ -59,7 +59,7 @@
 	</table>
 	<div id="maps"></div>
 
-	<script src="//cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.5/leaflet-src.js"></script>
+	<script src="//cdnjs.cloudflare.com/ajax/libs/leaflet/1.0.0-rc.1/leaflet-src.js"></script>
 	<script src="../leaflet-providers.js"></script>
 
 	<script src="shared.js"></script>

--- a/tests/index.html
+++ b/tests/index.html
@@ -3,7 +3,7 @@
 	<meta charset="utf-8">
 	<title>leaflet-poviders Mocha Tests</title>
 	<link rel="stylesheet" href="../node_modules/mocha/mocha.css" />
-	<link rel="stylesheet" href="http://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.3/leaflet.css" />
+	<link rel="stylesheet" href="http://cdnjs.cloudflare.com/ajax/libs/leaflet/1.0.0-rc.1/leaflet.css" />
 
 	<!--[if lte IE 8]>
 	<link rel="stylesheet" href="../node_modules/dist/leaflet.ie.css" />
@@ -22,7 +22,7 @@
 	<script src="../node_modules/chai/chai.js"></script>
 	<script src="../node_modules/mocha/mocha.js"></script>
 
-	<script src="http://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.3/leaflet-src.js"></script>
+	<script src="http://cdnjs.cloudflare.com/ajax/libs/leaflet/1.0.0-rc.1/leaflet-src.js"></script>
 	<script src="../leaflet-providers.js"></script>
 	<script src="../preview/shared.js"></script>
 

--- a/tests/test.js
+++ b/tests/test.js
@@ -15,7 +15,7 @@ var validTileLayerOptions = [
 	'minZoom', 'maxZoom', 'maxNativeZoom', 'tileSize', 'subdomains', 'errorTileUrl',
 	'attribution', 'tms', 'continuousWorld', 'noWrap', 'zoomOffset', 'zoomReverse',
 	'opacity', 'zIndex', 'unloadInvisibleTiles', 'updateWhenIdle', 'detectRetina',
-	'reuseTiles', 'bounds'
+	'reuseTiles', 'bounds', 'crossOrigin', 'updateInterval', 'pane', 'nonBubblingEvents'
 ];
 
 // monkey-patch getTileUrl with fake values.


### PR DESCRIPTION
- Bump Leaflet to 1.0.0-rc.1, 
- update eslint to 2.7, 
- lint inline js using eslint-plugin-html
- Fixed `test-https-support.html` and updated layout a bit
- Add new `L.TileLayer` options to the list of valid options for tilelayers.