### PR TITLE
Adding some layers from justicemaps.org

### DIFF
--- a/leaflet-providers.js
+++ b/leaflet-providers.js
@@ -628,6 +628,30 @@
 				maxZoom: 18,
 				subdomains: '0123',
 			}
+		},
+		JusticeMap: {
+			// Justice Map (http://www.justicemap.org/)
+			// Visualize race and income data for your community, county and country.
+			// Includes tools for data journalists, bloggers and community activists.
+			url: 'http://www.justicemap.org/tile/{size}/{variant}/{z}/{x}/{y}.png',
+			options: {
+				attribution: '<a href="http://www.justicemap.org/terms.php">Justice Map</a>',
+				// one of 'county', 'tract', 'block'
+				size: 'county',
+				// Bounds for USA, including Alaska and Hawaii
+				bounds: [[14, -180], [72, -56]]
+			},
+			variants: {
+				income: 'income',
+				americanIndian: 'indian',
+				asian: 'asian',
+				black: 'black',
+				hispanic: 'hispanic',
+				multi: 'multi',
+				nonWhite: 'nonwhite',
+				white: 'white',
+				plurality: 'plural'
+			}
 		}
 	};
 

--- a/preview/preview.js
+++ b/preview/preview.js
@@ -1,11 +1,9 @@
 (function () {
 	'use strict';
 
-	var map = new L.Map('map', {
+	var map = L.map('map', {
 		zoomControl: false,
-		center: [48, -3],
-		zoom: 5
-	});
+	}).setView([48, -3], 5);
 
 	function escapeHtml (string) {
 		return string
@@ -69,7 +67,8 @@
 			'OpenMapSurfer.AdminBounds',
 			'Stamen.Toner(Hybrid|Lines|Labels)',
 			'Acetate.(foreground|labels|roads)',
-			'Hydda.RoadsAndLabels'
+			'Hydda.RoadsAndLabels',
+			'^JusticeMap'
 		];
 
 		return providerName.match('(' + overlayPatterns.join('|') + ')') !== null;


### PR DESCRIPTION
Some time ago Aaron Kreider contacted me about layers available at http://www.justicemap.org. This is a quick implementation of some of them.

> Jan,
> 
> I recently found out about leaflet-providers.  It looks like you are
> doing a lot of work on this project, so I am writing you to let you know
> that I've made some open map layers for the US for race and income based
> on open source US census data.
> 
> These layers are available with a nice UI at www.justicemap.org.
> 
> They are also available directly.
> 
> http://www.justicemap.org/tile/[size]/[layer-name]/(zoom)/(coord.x)/(coord.y).png;
> 
> There are over 40 layers as I broke race into different groups (as well
> as having a more useful "plurality" layer"), and I also used different
> geographical resolutions (ranging from Census defined counties - of
> which the US has 3000, to blocks - which the US has 10 million)
> 
> See "Including the Map Tile Layers with Javascript"
> http://www.justicemap.org/include_map.php
> 
> I'm wondering how we could best incorporate these tile layers into the
> leaflet-providers project?  I have not used leaflet (I use Google Maps),
> so if you are interested in adding them yourself that would be greatly
> appreciated!  And I'd be happy to advise in any way that I could. For
> instance, I could recommend a subset of the layers that are the most
> useful.
> 
> Best wishes,
> 
> Aaron
