### PR TITLE
BasemapAT switch to https only with 2017-01-01

### DIFF
--- a/leaflet-providers.js
+++ b/leaflet-providers.js
@@ -528,7 +528,7 @@
 			}
 		},
 		BasemapAT: {
-			url: '//maps{s}.wien.gv.at/basemap/{variant}/normal/google3857/{z}/{y}/{x}.{format}',
+			url: 'https://maps{s}.wien.gv.at/basemap/{variant}/normal/google3857/{z}/{y}/{x}.{format}',
 			options: {
 				maxZoom: 19,
 				attribution: 'Datenquelle: <a href="www.basemap.at">basemap.at</a>',


### PR DESCRIPTION
https://www.data.gv.at/2016/08/04/mit-1-1-2017-basemap-at-nur-mehr-via-https-moeglich/