### PR TITLE
basemapAT supports maxZoom 20

### DIFF
--- a/leaflet-providers.js
+++ b/leaflet-providers.js
@@ -538,7 +538,12 @@
 				variant: 'geolandbasemap'
 			},
 			variants: {
-				basemap: 'geolandbasemap',
+				basemap: {
+					options: {
+						maxZoom: 20, // currently only in Vienna
+						variant: 'geolandbasemap'
+					}
+				},
 				grau: 'bmapgrau',
 				overlay: 'bmapoverlay',
 				highdpi: {
@@ -549,6 +554,7 @@
 				},
 				orthofoto: {
 					options: {
+						maxZoom: 20, // currently only in Vienna
 						variant: 'bmaporthofoto30cm',
 						format: 'jpeg'
 					}


### PR DESCRIPTION
basemapAT supports maxZoom 20 (currently only in Vienna) in layer geolandbasemp and bmaporthofoto30cm
(http://de.slideshare.net/DigitalesWien/aktuelle-informationenen-zu-den-ogdgeoservices Slide: 9-14)