### PR TITLE
Add https support for CartoDB

### DIFF
--- a/leaflet-providers.js
+++ b/leaflet-providers.js
@@ -51,15 +51,15 @@
 			}
 
 			var forceHTTP = window.location.protocol === 'file:' || provider.options.forceHTTP;
-      if (forceHTTP) {
-        if (provider.url.indexOf('//') === 0) {
-  				provider.url = 'http:' + provider.url;
-  			}
-        // Check if url2 exists and has http protocol
-        else if (providers[providerName].url2 && providers[providerName].url2.indexOf('http:') === 0) {
-          provider.url = providers[providerName].url2;
-        }
-      }
+			if (forceHTTP) {
+				if (provider.url.indexOf('//') === 0) {
+					provider.url = 'http:' + provider.url;
+				}
+				// Check if url2 exists and has http protocol
+				else if (providers[providerName].url2 && providers[providerName].url2.indexOf('http:') === 0) {
+					provider.url = providers[providerName].url2;
+				}
+			}
 
 			// If retina option is set
 			if (provider.options.retina) {
@@ -501,7 +501,7 @@
 		},
 		CartoDB: {
 			url: 'https://cartodb-basemaps-{s}.global.ssl.fastly.net/{variant}/{z}/{x}/{y}.png',
-      url2: 'http://{s}.basemaps.cartocdn.com/{variant}/{z}/{x}/{y}.png',
+			url2: 'http://{s}.basemaps.cartocdn.com/{variant}/{z}/{x}/{y}.png',
 			options: {
 				attribution: '{attribution.OpenStreetMap} &copy; <a href="http://cartodb.com/attributions">CartoDB</a>',
 				subdomains: 'abcd',

--- a/leaflet-providers.js
+++ b/leaflet-providers.js
@@ -51,9 +51,15 @@
 			}
 
 			var forceHTTP = window.location.protocol === 'file:' || provider.options.forceHTTP;
-			if (provider.url.indexOf('//') === 0 && forceHTTP) {
-				provider.url = 'http:' + provider.url;
-			}
+      if (forceHTTP) {
+        if (provider.url.indexOf('//') === 0) {
+  				provider.url = 'http:' + provider.url;
+  			}
+        // Check if url2 exists and has http protocol
+        else if (providers[providerName].url2 && providers[providerName].url2.indexOf('http:') === 0) {
+          provider.url = providers[providerName].url2;
+        }
+      }
 
 			// If retina option is set
 			if (provider.options.retina) {
@@ -494,7 +500,8 @@
 			}
 		},
 		CartoDB: {
-			url: 'http://{s}.basemaps.cartocdn.com/{variant}/{z}/{x}/{y}.png',
+			url: 'https://cartodb-basemaps-{s}.global.ssl.fastly.net/{variant}/{z}/{x}/{y}.png',
+      url2: 'http://{s}.basemaps.cartocdn.com/{variant}/{z}/{x}/{y}.png',
 			options: {
 				attribution: '{attribution.OpenStreetMap} &copy; <a href="http://cartodb.com/attributions">CartoDB</a>',
 				subdomains: 'abcd',


### PR DESCRIPTION
Fix #189 

The idea is to have two properties, `url` and `url2` for https and http protocols respectively, for those basemaps whose links are different for the two protocols (when `//` does not do the job).