### PR TITLE
Make preview usable locally

### DIFF
--- a/preview/index.html
+++ b/preview/index.html
@@ -6,7 +6,7 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 
-	<link rel="stylesheet" href="//unpkg.com/leaflet@1.0.3/dist/leaflet.css" />
+	<link rel="stylesheet" href="https://unpkg.com/leaflet@1.0.3/dist/leaflet.css" />
 
 	<style>
 		html {
@@ -77,7 +77,7 @@
 	</div>
 	<div id="map" class="map"></div>
 
-	<script src="//unpkg.com/leaflet@1.0.3/dist/leaflet.js"></script>
+	<script src="https://unpkg.com/leaflet@1.0.3/dist/leaflet.js"></script>
 	<script src="../leaflet-providers.js"></script>
 
 	<script src="vendor/L.Control.Layers.Minimap.js"></script>


### PR DESCRIPTION
No explicit protocoll has been used for the leaflet files hosted on unpkg.com, resulting in use of the file:// handle when opened locally - hence the preview didn't work. With the explicit protocoll it works from ones hard drive as well, after cloning the repository for use in an own project for example.