### PR TITLE
Add retina support for Mapbox

### DIFF
--- a/leaflet-providers.js
+++ b/leaflet-providers.js
@@ -262,7 +262,7 @@
 			}
 		},
 		MapBox: {
-			url: 'https://api.tiles.mapbox.com/v4/{id}/{z}/{x}/{y}.png?access_token={accessToken}',
+			url: 'https://api.tiles.mapbox.com/v4/{id}/{z}/{x}/{y}{r}.png?access_token={accessToken}',
 			options: {
 				attribution:
 					'Imagery from <a href="http://mapbox.com/about/maps/">MapBox</a> &mdash; ' +


### PR DESCRIPTION
Mapbox's old "v4" API as used here has documented support for Retina tiles:

> You can prefix the format with `@2x` to request a high DPI version. The `@2x` is placed after the `{z}/{x}/{y}` and before the `.`, like `1/0/0@2x.png`