### PR TITLE
Add Carto "Voyager" tiles

### DIFF
--- a/leaflet-providers.js
+++ b/leaflet-providers.js
@@ -561,7 +561,11 @@
 				PositronOnlyLabels: 'light_only_labels',
 				DarkMatter: 'dark_all',
 				DarkMatterNoLabels: 'dark_nolabels',
-				DarkMatterOnlyLabels: 'dark_only_labels'
+				DarkMatterOnlyLabels: 'dark_only_labels',
+				Voyager: 'rastertiles/voyager',
+				VoyagerNoLabels: 'rastertiles/voyager_nolabels',
+				VoyagerOnlyLabels: 'rastertiles/voyager_only_labels',
+				VoyagerLabelsUnder: 'rastertiles/voyager_labels_under'
 			}
 		},
 		HikeBike: {


### PR DESCRIPTION
The newer Voyager tiles are available under the same terms as Positron and Dark Matter, confirmed by https://github.com/CartoDB/basemap-styles#1-web-raster-basemaps