### PR TITLE
Remove homegrown retina detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,6 @@ L.tileLayer.provider('Stamen.Watercolor').addTo(map);
 
 Leaflet-providers tries to use `https://` if the page uses `https://` and the provider supports it.
 
-## Retina tiles
-
-Some providers have retina tiles for which the URL only needs to be slightly adjusted, e.g. `-----@2x.png`. For this, add the retina option in the URL, e.g. `-----{retina}.png`, and set a retina value in the options, e.g. `retina: '@2x'`. If Leaflet detects a retina screen (`L.Browser.retina`), the retina option passed to the tileLayer is set to the value supplied, otherwise it's replaced by an empty string.
-
 # Providers
 
 Leaflet-providers provides tile layers from different providers, including *OpenStreetMap*, *Stamen*, *Esri* and *OpenWeatherMap*. The full listing of free to use layers can be [previewed](http://leaflet-extras.github.io/leaflet-providers/preview/index.html). The page will show you the name to use with `leaflet-providers.js` and the code to use it without dependencies.

--- a/leaflet-providers.js
+++ b/leaflet-providers.js
@@ -50,19 +50,6 @@
 				};
 			}
 
-			// If retina option is set
-			if (provider.options.retina) {
-				// Check retina screen
-				if (options.detectRetina && L.Browser.retina) {
-					// The retina option will be active now
-					// But we need to prevent Leaflet retina mode
-					options.detectRetina = false;
-				} else {
-					// No retina, remove option
-					provider.options.retina = '';
-				}
-			}
-
 			// replace attribution placeholders with their values from toplevel provider attribution,
 			// recursively
 			var attributionReplacer = function (attr) {
@@ -114,7 +101,7 @@
 					url: 'https://tile.osm.ch/switzerland/{z}/{x}/{y}.png',
 					options: {
 						maxZoom: 18,
-				                bounds: [[45, 5], [48, 11]]						
+						bounds: [[45, 5], [48, 11]]
 					}
 				},
 				France: {
@@ -143,14 +130,14 @@
 			url: 'https://tiles-{s}.openinframap.org/{variant}/{z}/{x}/{y}.png',
 			options: {
 				maxZoom: 18,
-				attribution: 
+				attribution:
 					'{attribution.OpenStreetMap}, <a href="http://www.openinframap.org/about.html">About OpenInfraMap</a>'
 			},
 			variants: {
-				  Power:       'power' ,
-				  Telecom:     'telecoms' ,
-				  Petroleum:   'petroleum' ,
-				  Water:       'water'
+				Power: 'power',
+				Telecom: 'telecoms',
+				Petroleum: 'petroleum',
+				Water: 'water'
 			}
 		},
 		OpenSeaMap: {

--- a/leaflet-providers.js
+++ b/leaflet-providers.js
@@ -260,7 +260,7 @@
 			}
 		},
 		Stamen: {
-			url: 'https://stamen-tiles-{s}.a.ssl.fastly.net/{variant}/{z}/{x}/{y}.{ext}',
+			url: 'https://stamen-tiles-{s}.a.ssl.fastly.net/{variant}/{z}/{x}/{y}{r}.{ext}',
 			options: {
 				attribution:
 					'Map tiles by <a href="http://stamen.com">Stamen Design</a>, ' +
@@ -535,7 +535,7 @@
 			}
 		},
 		CartoDB: {
-			url: 'https://cartodb-basemaps-{s}.global.ssl.fastly.net/{variant}/{z}/{x}/{y}.png',
+			url: 'https://cartodb-basemaps-{s}.global.ssl.fastly.net/{variant}/{z}/{x}/{y}{r}.png',
 			options: {
 				attribution: '{attribution.OpenStreetMap} &copy; <a href="http://cartodb.com/attributions">CartoDB</a>',
 				subdomains: 'abcd',


### PR DESCRIPTION
and
- some indentation cleanup.
- add `{r}` to Stamen and CartoDB urls (replaces #257 and #251)