### PR TITLE
adding geoportail france provider (new try)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ In order to use ArcGIS maps, you must [register](https://developers.arcgis.com/e
 
 ### Geoportail France
 
-In order to use Geoportail France resources, you need to obtain a [api key]( http://professionnels.ign.fr/ign/contrats/) that gives you rigths on geoportal [resources](https://geoservices.ign.fr/documentation/donnees-ressources-wmts.html#ressources-servies-en-wmts-en-projection-web-mercator). Pass your api key andresource ID to L.tileLayer.provider` in the options: 
+In order to use Geoportail France resources, you need to obtain an [api key]( http://professionnels.ign.fr/ign/contrats/) that allows you to access the [resources](https://geoservices.ign.fr/documentation/donnees-ressources-wmts.html#ressources-servies-en-wmts-en-projection-web-mercator) you need. Pass this api key and the ID of the resource to display to `L.tileLayer.provider` in the options: 
 ```JavaScript
 L.tileLayer.provider('GeoportailFrance', {
     variant: '<insert resource ID here>',
@@ -79,7 +79,9 @@ L.tileLayer.provider('GeoportailFrance', {
 }).addTo(map);
 ```
 
-Please note that by default a public apikey ('choisirgeoportail') is used that comes with no guarantee. 4 aliases are also provided for common resources : 'GeoportailFrance', 'GeoportailFrance.orthos', 'GeoportailFrance.ignMaps' and 'GeoportailFrance.parcels' (See index.html demo).
+Please note that a public api key (`choisirgeoportail`) is used by default and comes with no guarantee. 
+
+4 aliases are also provided for common Geoportail resources : `GeoportailFrance`, `GeoportailFrance.orthos`, `GeoportailFrance.ignMaps` and `GeoportailFrance.parcels` (See index.html demo).
 
 
 # Attribution

--- a/README.md
+++ b/README.md
@@ -69,6 +69,19 @@ In order to use ArcGIS maps, you must [register](https://developers.arcgis.com/e
 
 [Available Esri layers](http://leaflet-extras.github.io/leaflet-providers/preview/#filter=Esri)
 
+### Geoportail France
+
+In order to use Geoportail France resources, you need to obtain a [api key]( http://professionnels.ign.fr/ign/contrats/) that gives you rigths on geoportal [resources](https://geoservices.ign.fr/documentation/donnees-ressources-wmts.html#ressources-servies-en-wmts-en-projection-web-mercator). Pass your api key andresource ID to L.tileLayer.provider` in the options: 
+```JavaScript
+L.tileLayer.provider('GeoportailFrance', {
+    variant: '<insert resource ID here>',
+    apikey: '<insert api key here>'
+}).addTo(map);
+```
+
+Please note that by default a public apikey ('choisirgeoportail') is used that comes with no guarantee. 4 aliases are also provided for common resources : 'GeoportailFrance', 'GeoportailFrance.orthos', 'GeoportailFrance.ign_maps' and 'GeoportailFrance.parcels' (See index.html demo).
+
+
 # Attribution
 
 This work was inspired from <https://gist.github.com/1804938>, and originally created by [Stefan Seelmann](https://github.com/seelmann).

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ L.tileLayer.provider('GeoportailFrance', {
 }).addTo(map);
 ```
 
-Please note that by default a public apikey ('choisirgeoportail') is used that comes with no guarantee. 4 aliases are also provided for common resources : 'GeoportailFrance', 'GeoportailFrance.orthos', 'GeoportailFrance.ign_maps' and 'GeoportailFrance.parcels' (See index.html demo).
+Please note that by default a public apikey ('choisirgeoportail') is used that comes with no guarantee. 4 aliases are also provided for common resources : 'GeoportailFrance', 'GeoportailFrance.orthos', 'GeoportailFrance.ignMaps' and 'GeoportailFrance.parcels' (See index.html demo).
 
 
 # Attribution

--- a/index.html
+++ b/index.html
@@ -61,7 +61,7 @@
 			'Esri WorldGrayCanvas': L.tileLayer.provider('Esri.WorldGrayCanvas'),
 			'Geoportail France Maps': L.tileLayer.provider('GeoportailFrance'),
 			'Geoportail France Orthos': L.tileLayer.provider('GeoportailFrance.orthos'),
-			'Geoportail France classic maps': L.tileLayer.provider('GeoportailFrance.ign_maps')
+			'Geoportail France classic maps': L.tileLayer.provider('GeoportailFrance.ignMaps')
 		};
 
 		var overlayLayers = {

--- a/index.html
+++ b/index.html
@@ -58,7 +58,10 @@
 			'Esri WorldPhysical': L.tileLayer.provider('Esri.WorldPhysical'),
 			'Esri OceanBasemap': L.tileLayer.provider('Esri.OceanBasemap'),
 			'Esri NatGeoWorldMap': L.tileLayer.provider('Esri.NatGeoWorldMap'),
-			'Esri WorldGrayCanvas': L.tileLayer.provider('Esri.WorldGrayCanvas')
+			'Esri WorldGrayCanvas': L.tileLayer.provider('Esri.WorldGrayCanvas'),
+			'Geoportail France Maps': L.tileLayer.provider('GeoportailFrance'),
+			'Geoportail France Orthos': L.tileLayer.provider('GeoportailFrance.orthos'),
+			'Geoportail France classic maps': L.tileLayer.provider('GeoportailFrance.ign_maps')
 		};
 
 		var overlayLayers = {
@@ -73,7 +76,8 @@
 			'OpenWeatherMap PressureContour': L.tileLayer.provider('OpenWeatherMap.PressureContour'),
 			'OpenWeatherMap Wind': L.tileLayer.provider('OpenWeatherMap.Wind'),
 			'OpenWeatherMap Temperature': L.tileLayer.provider('OpenWeatherMap.Temperature'),
-			'OpenWeatherMap Snow': L.tileLayer.provider('OpenWeatherMap.Snow')
+			'OpenWeatherMap Snow': L.tileLayer.provider('OpenWeatherMap.Snow'),
+			'Geoportail France Parcels': L.tileLayer.provider('GeoportailFrance.parcels')
 		};
 
 		L.control.layers(baseLayers, overlayLayers, {collapsed: false}).addTo(map);

--- a/leaflet-providers.js
+++ b/leaflet-providers.js
@@ -728,6 +728,39 @@
 				minZoom: 1,
 				maxZoom: 19
 			}
+		},
+		GeoportailFrance: {
+			url: '//wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET=PM&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}',
+			options: {
+				attribution: '<a target="_blank" href="https://www.geoportail.gouv.fr/">Geoportail France</a>',
+				bounds: [[-75, -180], [81, 180]],
+				minZoom: 2,
+				maxZoom: 18,
+				// Get your own geoportail apikey here : http://professionnels.ign.fr/ign/contrats/
+				// NB : 'choisirgeoportail' is a demonstration key that comes with no guarantee
+				apikey: 'choisirgeoportail',
+				format: 'image/jpeg',
+				style : 'normal',
+				variant: 'GEOGRAPHICALGRIDSYSTEMS.MAPS.SCAN-EXPRESS.STANDARD'
+			},
+			variants: {
+				parcels: {
+					options : {
+						variant: 'CADASTRALPARCELS.PARCELS',
+						maxZoom: 20,
+						style : 'bdparcellaire',
+						format: 'image/png'
+					}
+				},
+				ign_maps: 'GEOGRAPHICALGRIDSYSTEMS.MAPS',
+				maps: 'GEOGRAPHICALGRIDSYSTEMS.MAPS.SCAN-EXPRESS.STANDARD',
+				orthos: {
+					options: {
+						maxZoom: 19,
+						variant: 'ORTHOIMAGERY.ORTHOPHOTOS'
+					}
+				}
+			}
 		}
 	};
 

--- a/leaflet-providers.js
+++ b/leaflet-providers.js
@@ -730,7 +730,7 @@
 			}
 		},
 		GeoportailFrance: {
-			url: '//wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET=PM&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}',
+			url: 'https://wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE={style}&TILEMATRIXSET=PM&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}',
 			options: {
 				attribution: '<a target="_blank" href="https://www.geoportail.gouv.fr/">Geoportail France</a>',
 				bounds: [[-75, -180], [81, 180]],

--- a/leaflet-providers.js
+++ b/leaflet-providers.js
@@ -752,7 +752,7 @@
 						format: 'image/png'
 					}
 				},
-				ign_maps: 'GEOGRAPHICALGRIDSYSTEMS.MAPS',
+				ignMaps: 'GEOGRAPHICALGRIDSYSTEMS.MAPS',
 				maps: 'GEOGRAPHICALGRIDSYSTEMS.MAPS.SCAN-EXPRESS.STANDARD',
 				orthos: {
 					options: {


### PR DESCRIPTION
This PR adds Geoportail France provider to leaflet-providers. Same goal as @fionnh previous unmerged PR (#279). The code comes from Mediawiki Extension:Maps latest evolution (https://github.com/JeroenDeDauw/Maps/pull/437) which uses  leaflet-providers as a dependency.

![geoportail-provider](https://user-images.githubusercontent.com/8211614/41440897-a0d5fa9a-7030-11e8-9a81-5c842c33ace2.jpg)

 
