### PR TITLE
Do not use retina suffix on some Stamen basemaps

### DIFF
--- a/leaflet-providers.js
+++ b/leaflet-providers.js
@@ -260,7 +260,7 @@
 			}
 		},
 		Stamen: {
-			url: 'https://stamen-tiles-{s}.a.ssl.fastly.net/{variant}/{z}/{x}/{y}{r}.{ext}',
+			url: 'https://stamen-tiles-{s}.a.ssl.fastly.net/{variant}/{z}/{x}/{y}{retinaSuffix}.{ext}',
 			options: {
 				attribution:
 					'Map tiles by <a href="http://stamen.com">Stamen Design</a>, ' +
@@ -270,7 +270,8 @@
 				minZoom: 0,
 				maxZoom: 20,
 				variant: 'toner',
-				ext: 'png'
+				ext: 'png',
+				retinaSuffix: L.Browser.retina ? '@2x' : ''
 			},
 			variants: {
 				Toner: 'toner',
@@ -283,7 +284,8 @@
 					options: {
 						variant: 'watercolor',
 						minZoom: 1,
-						maxZoom: 16
+						maxZoom: 16,
+						retinaSuffix: ''
 					}
 				},
 				Terrain: {
@@ -304,7 +306,8 @@
 					options: {
 						variant: 'toposm-color-relief',
 						ext: 'jpg',
-						bounds: [[22, -132], [51, -56]]
+						bounds: [[22, -132], [51, -56]],
+						retinaSuffix: ''
 					}
 				},
 				TopOSMFeatures: {


### PR DESCRIPTION
This *should* fix #283 by explicitly setting the retina suffix to an empty string (instead of using the Leaflet default hard-coded in the `L.TileLayer` code), but I haven't really tested it.

This is an alternative to #286.