### PR TITLE
Avoid a 301 redirect for Stamen watercolors

### DIFF
--- a/leaflet-providers.js
+++ b/leaflet-providers.js
@@ -280,7 +280,7 @@
 				TonerLabels: 'toner-labels',
 				TonerLite: 'toner-lite',
 				Watercolor: {
-					url: 'https://stamen-tiles-{s}.a.ssl.fastly.net/{variant}/{z}/{x}/{y}.{ext}',
+					url: 'https://stamen-tiles-{s}.a.ssl.fastly.net/{variant}/{z}/{x}/{y}.jpg',
 					options: {
 						variant: 'watercolor',
 						minZoom: 1,

--- a/leaflet-providers.js
+++ b/leaflet-providers.js
@@ -280,9 +280,10 @@
 				TonerLabels: 'toner-labels',
 				TonerLite: 'toner-lite',
 				Watercolor: {
-					url: 'https://stamen-tiles-{s}.a.ssl.fastly.net/{variant}/{z}/{x}/{y}.jpg',
+					url: 'https://stamen-tiles-{s}.a.ssl.fastly.net/{variant}/{z}/{x}/{y}.{ext}',
 					options: {
 						variant: 'watercolor',
+						ext: 'jpg',
 						minZoom: 1,
 						maxZoom: 16
 					}


### PR DESCRIPTION
Stamen only provides jpg watercolors tiles and redirects permanently png toward the jpg .
Avoid that 301 redirection and just use jpg urls