### PR TITLE
Tile attribution improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+/node_modules
 leaflet-providers.min.js

--- a/leaflet-providers.js
+++ b/leaflet-providers.js
@@ -81,7 +81,7 @@
 			options: {
 				maxZoom: 19,
 				attribution:
-					'&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'
+					'&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
 			},
 			variants: {
 				Mapnik: {},

--- a/leaflet-providers.js
+++ b/leaflet-providers.js
@@ -114,7 +114,10 @@
 				HOT: {
 					url: 'https://{s}.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png',
 					options: {
-						attribution: '{attribution.OpenStreetMap}, Tiles courtesy of <a href="http://hot.openstreetmap.org/" target="_blank">Humanitarian OpenStreetMap Team</a>'
+						attribution:
+							'{attribution.OpenStreetMap}, ' +
+							'Tiles style by <a href="https://www.hotosm.org/" target="_blank">Humanitarian OpenStreetMap Team</a> ' +
+							'hosted by <a href="https://openstreetmap.fr/" target="_blank">OpenStreetMap France</a>'
 					}
 				},
 				BZH: {

--- a/leaflet-providers.js
+++ b/leaflet-providers.js
@@ -241,8 +241,9 @@
 			url: 'https://api.tiles.mapbox.com/v4/{id}/{z}/{x}/{y}{r}.png?access_token={accessToken}',
 			options: {
 				attribution:
-					'Imagery from <a href="http://mapbox.com/about/maps/">MapBox</a> &mdash; ' +
-					'Map data {attribution.OpenStreetMap}',
+					'<a href="https://www.mapbox.com/about/maps/" target="_blank">&copy; Mapbox</a> ' +
+					'{attribution.OpenStreetMap} ' +
+					'<a href="https://www.mapbox.com/map-feedback/" target="_blank">Improve this map</a>',
 				subdomains: 'abcd',
 				id: 'mapbox.streets',
 				accessToken: '<insert your access token here>',

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "chai": "^4.1.2",
     "eslint": "^5.4.0",
-    "eslint-plugin-html": "^4.0.5",
+    "eslint-plugin-html": "^5.0.3",
     "mocha": "^5.2.0",
     "mocha-chrome": "^1.1.0",
     "mversion": "^1.12.0",


### PR DESCRIPTION
- Improve OSM attribution
  - Use "© OpenStreetMap contributors" instead of "© OpenStreetMap" as suggested on https://www.openstreetmap.org/copyright
  - Use https URL
- Update HOTOSM attributio: Use the same attribution as openstreetmap.org for the HOT tiles.
- Update Mapbox attribution: See https://docs.mapbox.com/help/how-mapbox-works/attribution/#text-attribution