### PR TITLE
Add maxNativeZoom key on each providers to allow pixelized tile (instead of a grey tile)

### DIFF
--- a/leaflet-providers.js
+++ b/leaflet-providers.js
@@ -25,9 +25,11 @@
 				throw 'No such provider (' + providerName + ')';
 			}
 
+			var opts = providers[providerName].options;
+			opts.maxNativeZoom = opts.maxZoom;
 			var provider = {
 				url: providers[providerName].url,
-				options: providers[providerName].options
+				options: opts,
 			};
 
 			// overwrite values in provider from variant.


### PR DESCRIPTION
Hi,

A small update I have done for a site i'm working on, the plugin allow a layer to be pixelized above maxZoom and not show a grey tile (like originaly).

I have done this because when you use a provider it "lock" the maxZoom value to the one in set in the providers list.
But if you want to use maxNativeZoom, the plugin will still try to fetch tiles with greater maxZoom than the one allowed and it will return grey tiles instead.

Thanks in advance :)
