### PR TITLE
Add Thunderforest 'Mobile Atlas' and 'Neighbourhood'

### DIFF
--- a/leaflet-providers.js
+++ b/leaflet-providers.js
@@ -192,7 +192,9 @@
 				},
 				Landscape: 'landscape',
 				Outdoors: 'outdoors',
-				Pioneer: 'pioneer'
+				Pioneer: 'pioneer',
+				MobileAtlas: 'mobile-atlas',
+				Neighbourhood: 'neighbourhood'
 			}
 		},
 		OpenMapSurfer: {


### PR DESCRIPTION
Add support for Thunderforest 'Mobile Atlas' and 'Neighbourhood'
map variants. These are currently missing and seem to have the
same usage conditions as layers already present.