### PR TITLE
Fix nlmaps.luchtfoto url

### DIFF
--- a/leaflet-providers.js
+++ b/leaflet-providers.js
@@ -692,7 +692,7 @@
 				'pastel': 'brtachtergrondkaartpastel',
 				'grijs': 'brtachtergrondkaartgrijs',
 				'luchtfoto': {
-					'url': 'https://geodata.nationaalgeoregister.nl/luchtfoto/rgb/wmts/1.0.0/2016_ortho25/EPSG:3857/{z}/{x}/{y}.png',
+					'url': 'https://geodata.nationaalgeoregister.nl/luchtfoto/rgb/wmts/2018_ortho25/EPSG:3857/{z}/{x}/{y}.png',
 				}
 			}
 		},


### PR DESCRIPTION
removed 1.0.0 and updated year to 2018.

example tile with new url: https://geodata.nationaalgeoregister.nl/luchtfoto/rgb/wmts/2018_ortho25/EPSG:3857/7/66/41.png

fixes: #338 