### PR TITLE
Hydda layers hosted at OpenStreetMap Sweden now support maxZoom 20.

### DIFF
--- a/leaflet-providers.js
+++ b/leaflet-providers.js
@@ -278,7 +278,7 @@
 		Hydda: {
 			url: 'https://{s}.tile.openstreetmap.se/hydda/{variant}/{z}/{x}/{y}.png',
 			options: {
-				maxZoom: 18,
+				maxZoom: 20,
 				variant: 'full',
 				attribution: 'Tiles courtesy of <a href="http://openstreetmap.se/" target="_blank">OpenStreetMap Sweden</a> &mdash; Map data {attribution.OpenStreetMap}'
 			},


### PR DESCRIPTION
Hi all!

I've just reinstalled the openstreetmap.se tile server. It now support maxZoom 20. 

It's cool to see that you use my base layer as the background for all overlays on the leaflet-providers site. We seem to have been getting quite a bump in the server load since that occurred. :D

FYI, I have also updated our style with Google Noto font to loose those pesky tofu [] characters in CJK-areas. We have prerendered z0-z12 of all our layers (full, base, labels and roads) but since we nowadays peek at 900 tiles per second and have rather limited hardware, the server is semi-slow at the moment. Those are rather crazy numbers, last time we checked it was 20 tiles per second.

Also managed to document the Hydda style a bit this time. There's always a bunch of people asking about hosting their own instance when we do maintenance. (This time we still served our 600GB cache, but didn't have disk space enough to keep a planet database on two VMs at the same time.)

https://github.com/karlwettin/carto-style-hydda

Feedback is most welcome.


Karl
OpenStreetMap Sweden