### PR TITLE
Add Jawg Maps provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,17 @@ L.tileLayer.provider('HERE.terrainDay', {
 }).addTo(map);
 ```
 
+### Jawg Maps
+
+In order to use Jawg Maps, you must [register](https://www.jawg.io/lab). Once registered, your access token will be located [here](https://www.jawg.io/lab/access-tokens) and you will access to all Jawg default maps (variants) and your own customized maps :
+
+```JavaScript
+L.tileLayer.provider('Jawg.Streets', {
+    variant: '<insert map id here or blank for default variant>',
+    accessToken: '<insert access token here>'
+}).addTo(map);
+```
+
 ### Mapbox
 
 In order to use Mapbox maps, you must [register](https://tiles.mapbox.com/signup). You can get map_ID (i.e mapbox.satellite) and ACCESS_TOKEN from [Mapbox projects](https://www.mapbox.com/projects):

--- a/index.html
+++ b/index.html
@@ -48,6 +48,8 @@
 			'Stamen Toner': L.tileLayer.provider('Stamen.Toner'),
 			'Stamen Terrain': L.tileLayer.provider('Stamen.Terrain'),
 			'Stamen Watercolor': L.tileLayer.provider('Stamen.Watercolor'),
+			'Jawg Streets': L.tileLayer.provider('Jawg.Streets'),
+			'Jawg Terrain': L.tileLayer.provider('Jawg.Terrain'),
 			'Esri WorldStreetMap': L.tileLayer.provider('Esri.WorldStreetMap'),
 			'Esri DeLorme': L.tileLayer.provider('Esri.DeLorme'),
 			'Esri WorldTopoMap': L.tileLayer.provider('Esri.WorldTopoMap'),

--- a/leaflet-providers.js
+++ b/leaflet-providers.js
@@ -288,6 +288,29 @@
 				RoadsAndLabels: 'roads_and_labels'
 			}
 		},
+		Jawg: {
+			url: 'https://{s}.tile.jawg.io/{variant}/{z}/{x}/{y}{r}.png?access-token={accessToken}',
+			options: {
+				attribution:
+					'<a href="http://jawg.io" title="Tiles Courtesy of Jawg Maps" target="_blank">&copy; <b>Jawg</b>Maps</a> ' +
+					'{attribution.OpenStreetMap}',
+				minZoom: 0,
+				maxZoom: 22,
+				subdomains: 'abcd',
+				variant: 'jawg-terrain',
+				// Get your own Jawg access token here : https://www.jawg.io/lab/
+				// NB : this is a demonstration key that comes with no guarantee
+				accessToken: 'PyTJUlEU1OPJwCJlW1k0NC8JIt2CALpyuj7uc066O7XbdZCjWEL3WYJIk6dnXtps',
+			},
+			variants: {
+				Streets: 'jawg-streets',
+				Terrain: 'jawg-terrain',
+				Sunny: 'jawg-sunny',
+				Dark: 'jawg-dark',
+				Light: 'jawg-light',
+				Matrix: 'jawg-matrix'
+			}
+		},
 		MapBox: {
 			url: 'https://api.tiles.mapbox.com/v4/{id}/{z}/{x}/{y}{r}.png?access_token={accessToken}',
 			options: {


### PR DESCRIPTION
Hi,

I added Jawg Maps as provider.
The access token has been created for a use on `leaflet-providers` website only.

More info here : https://www.jawg.io/