### PR TITLE
Use HTTPS to access unpkg

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 	<!-- Leaflet style. REQUIRED! -->
-	<link rel="stylesheet" href="http://unpkg.com/leaflet@1.0.3/dist/leaflet.css" />
+	<link rel="stylesheet" href="https://unpkg.com/leaflet@1.0.3/dist/leaflet.css" />
 	<style>
 		html { height: 100% }
 		body { height: 100%; margin: 0; padding: 0;}
@@ -26,7 +26,7 @@
 	</div>
 	<div id="map" class="map"></div>
 
-	<script src="http://unpkg.com/leaflet@1.0.3/dist/leaflet.js"></script>
+	<script src="https://unpkg.com/leaflet@1.0.3/dist/leaflet.js"></script>
 	<script src="leaflet-providers.js"></script>
 	<script>
 		var map = L.map('map', {


### PR DESCRIPTION
https://leaflet-extras.github.io/leaflet-providers/ shows as blank (in Firefox and Chrome), due to it requesting HTTP resources from an HTTPS page. This fixes the error, by replacing the resource links with HTTPS