### PR TITLE
Allow mouse-wheel scrolling of the leaflet styles menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,6 +93,12 @@
 		}
 		map.on('resize', resizeLayerControl);
 		resizeLayerControl();
+
+		var layerControl = document.getElementsByClassName('leaflet-control-layers')[0];
+		layerControl.addEventListener('wheel', function (e) {
+			e.stopPropagation();
+			return true;
+		});
 	</script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -95,10 +95,11 @@
 		resizeLayerControl();
 
 		var layerControl = document.getElementsByClassName('leaflet-control-layers')[0];
-		layerControl.addEventListener('wheel', function (e) {
-			e.stopPropagation();
-			return true;
-		});
+		if (layerControl.addEventListener){
+			layerControl.addEventListener('wheel', function (e) {
+				e.stopPropagation();
+			});
+		}
 	</script>
 </body>
 </html>


### PR DESCRIPTION
In small windows, the list of styles do not all fit on one screen. However, the mouse wheel is captured by the map, causing zooming instead of scrolling. This adds an event listener to prevent this propagation to the map itself when this list is scrolled.