### PR TITLE
Add Waymarked Trails overlay provider

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,7 +81,13 @@
 			'OpenWeatherMap Wind': L.tileLayer.provider('OpenWeatherMap.Wind'),
 			'OpenWeatherMap Temperature': L.tileLayer.provider('OpenWeatherMap.Temperature'),
 			'OpenWeatherMap Snow': L.tileLayer.provider('OpenWeatherMap.Snow'),
-			'Geoportail France Parcels': L.tileLayer.provider('GeoportailFrance.parcels')
+			'Geoportail France Parcels': L.tileLayer.provider('GeoportailFrance.parcels'),
+			'Waymarked Trails Hiking': L.tileLayer.provider('WaymarkedTrails.hiking'),
+			'Waymarked Trails Cycling': L.tileLayer.provider('WaymarkedTrails.cycling'),
+			'Waymarked Trails MTB': L.tileLayer.provider('WaymarkedTrails.mtb'),
+			'Waymarked Trails Ski Slopes': L.tileLayer.provider('WaymarkedTrails.slopes'),
+			'Waymarked Trails Riding': L.tileLayer.provider('WaymarkedTrails.riding'),
+			'Waymarked Trails Skating': L.tileLayer.provider('WaymarkedTrails.skating')
 		};
 
 		L.control.layers(baseLayers, overlayLayers, {collapsed: false}).addTo(map);

--- a/leaflet-providers.js
+++ b/leaflet-providers.js
@@ -1016,6 +1016,21 @@
 					url: 'https://basemap.nationalmap.gov/arcgis/rest/services/USGSImageryTopo/MapServer/tile/{z}/{y}/{x}'
 				}
 			}
+		},
+		WaymarkedTrails: {
+			url: 'https://tile.waymarkedtrails.org/{variant}/{z}/{x}/{y}.png',
+			options: {
+				maxZoom: 18,
+				attribution: 'Map data: {attribution.OpenStreetMap} | Map style: &copy; <a href="https://waymarkedtrails.org">waymarkedtrails.org</a> (<a href="https://creativecommons.org/licenses/by-sa/3.0/">CC-BY-SA</a>)'
+			},
+			variants: {
+				hiking: 'hiking',
+				cycling: 'cycling',
+				mtb: 'mtb',
+				slopes: 'slopes',
+				riding: 'riding',
+				skating: 'skating'
+			}
 		}
 	};
 


### PR DESCRIPTION
Adds 5 variants for https://waymarkedtrails.org/.

Attribution discussed and agreed on with copyright owner here: https://github.com/waymarkedtrails/waymarked-trails-site/issues/369