### PR TITLE
Migrate from travis to github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: CI
+on: [push, pull_request]
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2-beta
+      - run: npm install
+      - run: npm run lint
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2-beta
+      - run: npm install
+      - run: npm run testsuite

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
----
-language: node_js
-node_js:
-  - "node"
-notifications:
-   email: false
-git:
-  depth: 10


### PR DESCRIPTION
As mentioned in https://github.com/leaflet-extras/leaflet-providers/pull/373#issuecomment-728198664, migrate CI from travis to github actions.