### PR TITLE
Fix attribution link nlmaps

### DIFF
--- a/leaflet-providers.js
+++ b/leaflet-providers.js
@@ -834,7 +834,7 @@
 				minZoom: 6,
 				maxZoom: 19,
 				bounds: [[50.5, 3.25], [54, 7.6]],
-				attribution: 'Kaartgegevens &copy; <a href="kadaster.nl">Kadaster</a>'
+				attribution: 'Kaartgegevens &copy; <a href="https://www.kadaster.nl">Kadaster</a>'
 			},
 			variants: {
 				'standaard': 'brtachtergrondkaart',


### PR DESCRIPTION
Currently the attribution for nlmaps doesn't contain a protocol, resulting in a link to http(s)://domain.example/kadaster.nl. This small PR fixes this wrong link.