### PR TITLE
Move JusticeMap and OpenAIP to https, remove GeoportailFrance.ignMaps from index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,7 +62,6 @@
 			'Esri WorldGrayCanvas': L.tileLayer.provider('Esri.WorldGrayCanvas'),
 			'Geoportail France Maps': L.tileLayer.provider('GeoportailFrance'),
 			'Geoportail France Orthos': L.tileLayer.provider('GeoportailFrance.orthos'),
-			'Geoportail France classic maps': L.tileLayer.provider('GeoportailFrance.ignMaps'),
 			'USGS USTopo': L.tileLayer.provider('USGS.USTopo'),
 			'USGS USImagery': L.tileLayer.provider('USGS.USImagery'),
 			'USGS USImageryTopo': L.tileLayer.provider('USGS.USImageryTopo'),

--- a/leaflet-providers.js
+++ b/leaflet-providers.js
@@ -923,7 +923,7 @@
 			// Justice Map (http://www.justicemap.org/)
 			// Visualize race and income data for your community, county and country.
 			// Includes tools for data journalists, bloggers and community activists.
-			url: 'http://www.justicemap.org/tile/{size}/{variant}/{z}/{x}/{y}.png',
+			url: 'https://www.justicemap.org/tile/{size}/{variant}/{z}/{x}/{y}.png',
 			options: {
 				attribution: '<a href="http://www.justicemap.org/terms.php">Justice Map</a>',
 				// one of 'county', 'tract', 'block'
@@ -1024,7 +1024,7 @@
 			}
 		},
 		OpenAIP: {
-			url: 'http://{s}.tile.maps.openaip.net/geowebcache/service/tms/1.0.0/openaip_basemap@EPSG%3A900913@png/{z}/{x}/{y}.{ext}',
+			url: 'https://{s}.tile.maps.openaip.net/geowebcache/service/tms/1.0.0/openaip_basemap@EPSG%3A900913@png/{z}/{x}/{y}.{ext}',
 			options: {
 				attribution: '<a href="https://www.openaip.net/">openAIP Data</a> (<a href="https://creativecommons.org/licenses/by-sa/3.0/">CC-BY-NC-SA</a>)',
 				ext: 'png',


### PR DESCRIPTION
According to the test page:

https://leaflet-extras.github.io/leaflet-providers/preview/test-https-support.html

<img width="399" alt="Screenshot 2021-08-20 at 09 36 09" src="https://user-images.githubusercontent.com/1470389/130197963-651c37c9-b53a-4058-abc9-d64eccd433c4.png">
