### PR TITLE
RfC: migrate to Typescript, enable tree shaking

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,0 +1,2 @@
+export * from "./providers";
+export { Provider as default } from "./layer";

--- a/layer.ts
+++ b/layer.ts
@@ -1,5 +1,9 @@
 import * as L from "leaflet";
-import { ProviderDefinition } from "./providers";
+import {
+  ProviderDefinition,
+  osmAttribution,
+  esriAttribution,
+} from "./providers";
 
 interface ProviderLayer extends L.TileLayer {
   new (
@@ -34,20 +38,11 @@ export const Provider: ProviderLayer = L.TileLayer.extend({
       };
     }
 
-    // FIXME
-    // replace attribution placeholders with their values from toplevel provider attribution,
-    // recursively
-    // const attributionReplacer = function (attr: string) {
-    //   if (attr.indexOf("{attribution.") === -1) {
-    //     return attr;
-    //   }
-    //   return attr.replace(/\{attribution.(\w*)\}/g, (match, attributionName) =>
-    //     attributionReplacer(providers[attributionName].options.attribution)
-    //   );
-    // };
-    // provider.options.attribution = attributionReplacer(
-    //   provider.options.attribution
-    // );
+    if (typeof provider.options.attribution === "string") {
+      provider.options.attribution = provider.options.attribution
+        .replace(/\{attribution.OpenStreetMap\}/, osmAttribution)
+        .replace(/\{attribution.Esri\}/g, esriAttribution);
+    }
 
     // Compute final options combining provider options with any user overrides
     const layerOpts = L.Util.extend({}, provider.options, options);

--- a/layer.ts
+++ b/layer.ts
@@ -1,0 +1,60 @@
+import * as L from "leaflet";
+import { ProviderDefinition } from "./providers";
+
+interface ProviderLayer extends L.TileLayer {
+  new (
+    provider: ProviderDefinition,
+    variantName: string,
+    options?: L.TileLayerOptions
+  ): ProviderLayer;
+}
+
+export const Provider: ProviderLayer = L.TileLayer.extend({
+  initialize(
+    provider: ProviderDefinition,
+    variantName: string,
+    options?: L.TileLayerOptions
+  ) {
+    if (typeof provider !== "object") {
+      throw "No such provider!";
+    }
+
+    // overwrite values in provider from variant.
+    if (variantName && typeof provider.variants === "object") {
+      const variant = provider.variants[variantName];
+      if (typeof variant !== "string" && typeof variant !== "object") {
+        throw "No such variant (" + variantName + ")";
+      }
+      const variantOptions =
+        typeof variant === "string" ? { variant } : variant.options;
+      provider = {
+        url: (typeof variant === "object" && variant.url) || provider.url,
+        options: L.Util.extend({}, provider.options, variantOptions),
+        variants: {},
+      };
+    }
+
+    // FIXME
+    // replace attribution placeholders with their values from toplevel provider attribution,
+    // recursively
+    // const attributionReplacer = function (attr: string) {
+    //   if (attr.indexOf("{attribution.") === -1) {
+    //     return attr;
+    //   }
+    //   return attr.replace(/\{attribution.(\w*)\}/g, (match, attributionName) =>
+    //     attributionReplacer(providers[attributionName].options.attribution)
+    //   );
+    // };
+    // provider.options.attribution = attributionReplacer(
+    //   provider.options.attribution
+    // );
+
+    // Compute final options combining provider options with any user overrides
+    const layerOpts = L.Util.extend({}, provider.options, options);
+    (L.TileLayer.prototype as any).initialize.call(
+      this,
+      provider.url,
+      layerOpts
+    );
+  },
+}) as any;

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,10 +5,15 @@
     "requires": true,
     "packages": {
         "": {
+            "name": "leaflet-providers",
             "version": "1.13.0",
             "license": "BSD-2-Clause",
+            "dependencies": {
+                "@types/leaflet": "^1.7.6"
+            },
             "devDependencies": {
                 "chai": "^4.3.4",
+                "esbuild": "^0.13.14",
                 "eslint": "^8.0.0",
                 "eslint-plugin-html": "^6.1.2",
                 "mocha": "^9.0.3",
@@ -76,6 +81,19 @@
             },
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/@types/geojson": {
+            "version": "7946.0.8",
+            "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.8.tgz",
+            "integrity": "sha512-1rkryxURpr6aWP7R786/UQOkJ3PcpQiWkAXBmdWc7ryFWqN6a4xfK7BtjXvFBKO9LjQ+MWQSWxYeZX1OApnArA=="
+        },
+        "node_modules/@types/leaflet": {
+            "version": "1.7.6",
+            "resolved": "https://registry.npmjs.org/@types/leaflet/-/leaflet-1.7.6.tgz",
+            "integrity": "sha512-Emkz3V08QnlelSbpT46OEAx+TBZYTOX2r1yM7W+hWg5+djHtQ1GbEXBDRLaqQDOYcDI51Ss0ayoqoKD4CtLUDA==",
+            "dependencies": {
+                "@types/geojson": "*"
             }
         },
         "node_modules/@types/node": {
@@ -1222,6 +1240,256 @@
             "dependencies": {
                 "is-arrayish": "^0.2.1"
             }
+        },
+        "node_modules/esbuild": {
+            "version": "0.13.14",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.13.14.tgz",
+            "integrity": "sha512-xu4D+1ji9x53ocuomcY+KOrwAnWzhBu/wTEjpdgZ8I1c8i5vboYIeigMdzgY1UowYBKa2vZgVgUB32bu7gkxeg==",
+            "dev": true,
+            "hasInstallScript": true,
+            "bin": {
+                "esbuild": "bin/esbuild"
+            },
+            "optionalDependencies": {
+                "esbuild-android-arm64": "0.13.14",
+                "esbuild-darwin-64": "0.13.14",
+                "esbuild-darwin-arm64": "0.13.14",
+                "esbuild-freebsd-64": "0.13.14",
+                "esbuild-freebsd-arm64": "0.13.14",
+                "esbuild-linux-32": "0.13.14",
+                "esbuild-linux-64": "0.13.14",
+                "esbuild-linux-arm": "0.13.14",
+                "esbuild-linux-arm64": "0.13.14",
+                "esbuild-linux-mips64le": "0.13.14",
+                "esbuild-linux-ppc64le": "0.13.14",
+                "esbuild-netbsd-64": "0.13.14",
+                "esbuild-openbsd-64": "0.13.14",
+                "esbuild-sunos-64": "0.13.14",
+                "esbuild-windows-32": "0.13.14",
+                "esbuild-windows-64": "0.13.14",
+                "esbuild-windows-arm64": "0.13.14"
+            }
+        },
+        "node_modules/esbuild-android-arm64": {
+            "version": "0.13.14",
+            "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.13.14.tgz",
+            "integrity": "sha512-Q+Xhfp827r+ma8/DJgpMRUbDZfefsk13oePFEXEIJ4gxFbNv5+vyiYXYuKm43/+++EJXpnaYmEnu4hAKbAWYbA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "android"
+            ]
+        },
+        "node_modules/esbuild-darwin-64": {
+            "version": "0.13.14",
+            "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.13.14.tgz",
+            "integrity": "sha512-YmOhRns6QBNSjpVdTahi/yZ8dscx9ai7a6OY6z5ACgOuQuaQ2Qk2qgJ0/siZ6LgD0gJFMV8UINFV5oky5TFNQQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/esbuild-darwin-arm64": {
+            "version": "0.13.14",
+            "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.13.14.tgz",
+            "integrity": "sha512-Lp00VTli2jqZghSa68fx3fEFCPsO1hK59RMo1PRap5RUjhf55OmaZTZYnCDI0FVlCtt+gBwX5qwFt4lc6tI1xg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/esbuild-freebsd-64": {
+            "version": "0.13.14",
+            "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.13.14.tgz",
+            "integrity": "sha512-BKosI3jtvTfnmsCW37B1TyxMUjkRWKqopR0CE9AF2ratdpkxdR24Vpe3gLKNyWiZ7BE96/SO5/YfhbPUzY8wKw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "freebsd"
+            ]
+        },
+        "node_modules/esbuild-freebsd-arm64": {
+            "version": "0.13.14",
+            "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.13.14.tgz",
+            "integrity": "sha512-yd2uh0yf+fWv5114+SYTl4/1oDWtr4nN5Op+PGxAkMqHfYfLjFKpcxwCo/QOS/0NWqPVE8O41IYZlFhbEN2B8Q==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "freebsd"
+            ]
+        },
+        "node_modules/esbuild-linux-32": {
+            "version": "0.13.14",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.13.14.tgz",
+            "integrity": "sha512-a8rOnS1oWSfkkYWXoD2yXNV4BdbDKA7PNVQ1klqkY9SoSApL7io66w5H44mTLsfyw7G6Z2vLlaLI2nz9MMAowA==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/esbuild-linux-64": {
+            "version": "0.13.14",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.13.14.tgz",
+            "integrity": "sha512-yPZSoMs9W2MC3Dw+6kflKt5FfQm6Dicex9dGIr1OlHRsn3Hm7yGMUTctlkW53KknnZdOdcdd5upxvbxqymczVQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/esbuild-linux-arm": {
+            "version": "0.13.14",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.13.14.tgz",
+            "integrity": "sha512-8chZE4pkKRvJ/M/iwsNQ1KqsRg2RyU5eT/x2flNt/f8F2TVrDreR7I0HEeCR50wLla3B1C3wTIOzQBmjuc6uWg==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/esbuild-linux-arm64": {
+            "version": "0.13.14",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.13.14.tgz",
+            "integrity": "sha512-Lvo391ln9PzC334e+jJ2S0Rt0cxP47eoH5gFyv/E8HhOnEJTvm7A+RRnMjjHnejELacTTfYgFGQYPjLsi/jObQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/esbuild-linux-mips64le": {
+            "version": "0.13.14",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.13.14.tgz",
+            "integrity": "sha512-MZhgxbmrWbpY3TOE029O6l5tokG9+Yoj2hW7vdit/d/VnmneqeGrSHADuDL6qXM8L5jaCiaivb4VhsyVCpdAbQ==",
+            "cpu": [
+                "mips64el"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/esbuild-linux-ppc64le": {
+            "version": "0.13.14",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.13.14.tgz",
+            "integrity": "sha512-un7KMwS7fX1Un6BjfSZxTT8L5cV/8Uf4SAhM7WYy2XF8o8TI+uRxxD03svZnRNIPsN2J5cl6qV4n7Iwz+yhhVw==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/esbuild-netbsd-64": {
+            "version": "0.13.14",
+            "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.13.14.tgz",
+            "integrity": "sha512-5ekKx/YbOmmlTeNxBjh38Uh5TGn5C4uyqN17i67k18pS3J+U2hTVD7rCxcFcRS1AjNWumkVL3jWqYXadFwMS0Q==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "netbsd"
+            ]
+        },
+        "node_modules/esbuild-openbsd-64": {
+            "version": "0.13.14",
+            "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.13.14.tgz",
+            "integrity": "sha512-9bzvwewHjct2Cv5XcVoE1yW5YTW12Sk838EYfA46abgnhxGoFSD1mFcaztp5HHC43AsF+hQxbSFG/RilONARUA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "openbsd"
+            ]
+        },
+        "node_modules/esbuild-sunos-64": {
+            "version": "0.13.14",
+            "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.13.14.tgz",
+            "integrity": "sha512-mjMrZB76M6FmoiTvj/RGWilrioR7gVwtFBRVugr9qLarXMIU1W/pQx+ieEOtflrW61xo8w1fcxyHsVVGRvoQ0w==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "sunos"
+            ]
+        },
+        "node_modules/esbuild-windows-32": {
+            "version": "0.13.14",
+            "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.13.14.tgz",
+            "integrity": "sha512-GZa6mrx2rgfbH/5uHg0Rdw50TuOKbdoKCpEBitzmG5tsXBdce+cOL+iFO5joZc6fDVCLW3Y6tjxmSXRk/v20Hg==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/esbuild-windows-64": {
+            "version": "0.13.14",
+            "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.13.14.tgz",
+            "integrity": "sha512-Lsgqah24bT7ClHjLp/Pj3A9wxjhIAJyWQcrOV4jqXAFikmrp2CspA8IkJgw7HFjx6QrJuhpcKVbCAe/xw0i2yw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/esbuild-windows-arm64": {
+            "version": "0.13.14",
+            "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.13.14.tgz",
+            "integrity": "sha512-KP8FHVlWGhM7nzYtURsGnskXb/cBCPTfj0gOKfjKq2tHtYnhDZywsUG57nk7TKhhK0fL11LcejHG3LRW9RF/9A==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ]
         },
         "node_modules/escalade": {
             "version": "3.1.1",
@@ -4968,6 +5236,19 @@
                 "defer-to-connect": "^1.0.1"
             }
         },
+        "@types/geojson": {
+            "version": "7946.0.8",
+            "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.8.tgz",
+            "integrity": "sha512-1rkryxURpr6aWP7R786/UQOkJ3PcpQiWkAXBmdWc7ryFWqN6a4xfK7BtjXvFBKO9LjQ+MWQSWxYeZX1OApnArA=="
+        },
+        "@types/leaflet": {
+            "version": "1.7.6",
+            "resolved": "https://registry.npmjs.org/@types/leaflet/-/leaflet-1.7.6.tgz",
+            "integrity": "sha512-Emkz3V08QnlelSbpT46OEAx+TBZYTOX2r1yM7W+hWg5+djHtQ1GbEXBDRLaqQDOYcDI51Ss0ayoqoKD4CtLUDA==",
+            "requires": {
+                "@types/geojson": "*"
+            }
+        },
         "@types/node": {
             "version": "16.6.2",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-16.6.2.tgz",
@@ -5891,6 +6172,150 @@
             "requires": {
                 "is-arrayish": "^0.2.1"
             }
+        },
+        "esbuild": {
+            "version": "0.13.14",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.13.14.tgz",
+            "integrity": "sha512-xu4D+1ji9x53ocuomcY+KOrwAnWzhBu/wTEjpdgZ8I1c8i5vboYIeigMdzgY1UowYBKa2vZgVgUB32bu7gkxeg==",
+            "dev": true,
+            "requires": {
+                "esbuild-android-arm64": "0.13.14",
+                "esbuild-darwin-64": "0.13.14",
+                "esbuild-darwin-arm64": "0.13.14",
+                "esbuild-freebsd-64": "0.13.14",
+                "esbuild-freebsd-arm64": "0.13.14",
+                "esbuild-linux-32": "0.13.14",
+                "esbuild-linux-64": "0.13.14",
+                "esbuild-linux-arm": "0.13.14",
+                "esbuild-linux-arm64": "0.13.14",
+                "esbuild-linux-mips64le": "0.13.14",
+                "esbuild-linux-ppc64le": "0.13.14",
+                "esbuild-netbsd-64": "0.13.14",
+                "esbuild-openbsd-64": "0.13.14",
+                "esbuild-sunos-64": "0.13.14",
+                "esbuild-windows-32": "0.13.14",
+                "esbuild-windows-64": "0.13.14",
+                "esbuild-windows-arm64": "0.13.14"
+            }
+        },
+        "esbuild-android-arm64": {
+            "version": "0.13.14",
+            "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.13.14.tgz",
+            "integrity": "sha512-Q+Xhfp827r+ma8/DJgpMRUbDZfefsk13oePFEXEIJ4gxFbNv5+vyiYXYuKm43/+++EJXpnaYmEnu4hAKbAWYbA==",
+            "dev": true,
+            "optional": true
+        },
+        "esbuild-darwin-64": {
+            "version": "0.13.14",
+            "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.13.14.tgz",
+            "integrity": "sha512-YmOhRns6QBNSjpVdTahi/yZ8dscx9ai7a6OY6z5ACgOuQuaQ2Qk2qgJ0/siZ6LgD0gJFMV8UINFV5oky5TFNQQ==",
+            "dev": true,
+            "optional": true
+        },
+        "esbuild-darwin-arm64": {
+            "version": "0.13.14",
+            "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.13.14.tgz",
+            "integrity": "sha512-Lp00VTli2jqZghSa68fx3fEFCPsO1hK59RMo1PRap5RUjhf55OmaZTZYnCDI0FVlCtt+gBwX5qwFt4lc6tI1xg==",
+            "dev": true,
+            "optional": true
+        },
+        "esbuild-freebsd-64": {
+            "version": "0.13.14",
+            "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.13.14.tgz",
+            "integrity": "sha512-BKosI3jtvTfnmsCW37B1TyxMUjkRWKqopR0CE9AF2ratdpkxdR24Vpe3gLKNyWiZ7BE96/SO5/YfhbPUzY8wKw==",
+            "dev": true,
+            "optional": true
+        },
+        "esbuild-freebsd-arm64": {
+            "version": "0.13.14",
+            "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.13.14.tgz",
+            "integrity": "sha512-yd2uh0yf+fWv5114+SYTl4/1oDWtr4nN5Op+PGxAkMqHfYfLjFKpcxwCo/QOS/0NWqPVE8O41IYZlFhbEN2B8Q==",
+            "dev": true,
+            "optional": true
+        },
+        "esbuild-linux-32": {
+            "version": "0.13.14",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.13.14.tgz",
+            "integrity": "sha512-a8rOnS1oWSfkkYWXoD2yXNV4BdbDKA7PNVQ1klqkY9SoSApL7io66w5H44mTLsfyw7G6Z2vLlaLI2nz9MMAowA==",
+            "dev": true,
+            "optional": true
+        },
+        "esbuild-linux-64": {
+            "version": "0.13.14",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.13.14.tgz",
+            "integrity": "sha512-yPZSoMs9W2MC3Dw+6kflKt5FfQm6Dicex9dGIr1OlHRsn3Hm7yGMUTctlkW53KknnZdOdcdd5upxvbxqymczVQ==",
+            "dev": true,
+            "optional": true
+        },
+        "esbuild-linux-arm": {
+            "version": "0.13.14",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.13.14.tgz",
+            "integrity": "sha512-8chZE4pkKRvJ/M/iwsNQ1KqsRg2RyU5eT/x2flNt/f8F2TVrDreR7I0HEeCR50wLla3B1C3wTIOzQBmjuc6uWg==",
+            "dev": true,
+            "optional": true
+        },
+        "esbuild-linux-arm64": {
+            "version": "0.13.14",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.13.14.tgz",
+            "integrity": "sha512-Lvo391ln9PzC334e+jJ2S0Rt0cxP47eoH5gFyv/E8HhOnEJTvm7A+RRnMjjHnejELacTTfYgFGQYPjLsi/jObQ==",
+            "dev": true,
+            "optional": true
+        },
+        "esbuild-linux-mips64le": {
+            "version": "0.13.14",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.13.14.tgz",
+            "integrity": "sha512-MZhgxbmrWbpY3TOE029O6l5tokG9+Yoj2hW7vdit/d/VnmneqeGrSHADuDL6qXM8L5jaCiaivb4VhsyVCpdAbQ==",
+            "dev": true,
+            "optional": true
+        },
+        "esbuild-linux-ppc64le": {
+            "version": "0.13.14",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.13.14.tgz",
+            "integrity": "sha512-un7KMwS7fX1Un6BjfSZxTT8L5cV/8Uf4SAhM7WYy2XF8o8TI+uRxxD03svZnRNIPsN2J5cl6qV4n7Iwz+yhhVw==",
+            "dev": true,
+            "optional": true
+        },
+        "esbuild-netbsd-64": {
+            "version": "0.13.14",
+            "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.13.14.tgz",
+            "integrity": "sha512-5ekKx/YbOmmlTeNxBjh38Uh5TGn5C4uyqN17i67k18pS3J+U2hTVD7rCxcFcRS1AjNWumkVL3jWqYXadFwMS0Q==",
+            "dev": true,
+            "optional": true
+        },
+        "esbuild-openbsd-64": {
+            "version": "0.13.14",
+            "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.13.14.tgz",
+            "integrity": "sha512-9bzvwewHjct2Cv5XcVoE1yW5YTW12Sk838EYfA46abgnhxGoFSD1mFcaztp5HHC43AsF+hQxbSFG/RilONARUA==",
+            "dev": true,
+            "optional": true
+        },
+        "esbuild-sunos-64": {
+            "version": "0.13.14",
+            "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.13.14.tgz",
+            "integrity": "sha512-mjMrZB76M6FmoiTvj/RGWilrioR7gVwtFBRVugr9qLarXMIU1W/pQx+ieEOtflrW61xo8w1fcxyHsVVGRvoQ0w==",
+            "dev": true,
+            "optional": true
+        },
+        "esbuild-windows-32": {
+            "version": "0.13.14",
+            "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.13.14.tgz",
+            "integrity": "sha512-GZa6mrx2rgfbH/5uHg0Rdw50TuOKbdoKCpEBitzmG5tsXBdce+cOL+iFO5joZc6fDVCLW3Y6tjxmSXRk/v20Hg==",
+            "dev": true,
+            "optional": true
+        },
+        "esbuild-windows-64": {
+            "version": "0.13.14",
+            "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.13.14.tgz",
+            "integrity": "sha512-Lsgqah24bT7ClHjLp/Pj3A9wxjhIAJyWQcrOV4jqXAFikmrp2CspA8IkJgw7HFjx6QrJuhpcKVbCAe/xw0i2yw==",
+            "dev": true,
+            "optional": true
+        },
+        "esbuild-windows-arm64": {
+            "version": "0.13.14",
+            "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.13.14.tgz",
+            "integrity": "sha512-KP8FHVlWGhM7nzYtURsGnskXb/cBCPTfj0gOKfjKq2tHtYnhDZywsUG57nk7TKhhK0fL11LcejHG3LRW9RF/9A==",
+            "dev": true,
+            "optional": true
         },
         "escalade": {
             "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
         "url": "git://github.com/leaflet-extras/leaflet-providers.git"
     },
     "scripts": {
+        "build": "esbuild --bundle --external:leaflet index.ts --outdir=dist",
         "test": "npm run lint && npm run testsuite",
         "testsuite": "mocha-chrome tests/index.html",
         "lint": "eslint --config .eslintrc leaflet-providers.js index.html preview/*.js preview/*.html tests/*",
@@ -25,8 +26,12 @@
         "CHANGELOG.md",
         "licence.md"
     ],
+    "dependencies": {
+        "@types/leaflet": "^1.7.6"
+    },
     "devDependencies": {
         "chai": "^4.3.4",
+        "esbuild": "^0.13.14",
         "eslint": "^8.0.0",
         "eslint-plugin-html": "^6.1.2",
         "mocha": "^9.0.3",

--- a/providers/Esri.ts
+++ b/providers/Esri.ts
@@ -1,0 +1,91 @@
+import { ProviderDefinition } from ".";
+
+export const attribution = "Tiles &copy; Esri";
+
+export default {
+  url: "https://server.arcgisonline.com/ArcGIS/rest/services/{variant}/MapServer/tile/{z}/{y}/{x}",
+  options: {
+    variant: "World_Street_Map",
+    attribution,
+  },
+  variants: {
+    WorldStreetMap: {
+      options: {
+        attribution:
+          "{attribution.Esri} &mdash; " +
+          "Source: Esri, DeLorme, NAVTEQ, USGS, Intermap, iPC, NRCAN, Esri Japan, METI, Esri China (Hong Kong), Esri (Thailand), TomTom, 2012",
+      },
+    },
+    DeLorme: {
+      options: {
+        variant: "Specialty/DeLorme_World_Base_Map",
+        minZoom: 1,
+        maxZoom: 11,
+        attribution: "{attribution.Esri} &mdash; Copyright: &copy;2012 DeLorme",
+      },
+    },
+    WorldTopoMap: {
+      options: {
+        variant: "World_Topo_Map",
+        attribution:
+          "{attribution.Esri} &mdash; " +
+          "Esri, DeLorme, NAVTEQ, TomTom, Intermap, iPC, USGS, FAO, NPS, NRCAN, GeoBase, Kadaster NL, Ordnance Survey, Esri Japan, METI, Esri China (Hong Kong), and the GIS User Community",
+      },
+    },
+    WorldImagery: {
+      options: {
+        variant: "World_Imagery",
+        attribution:
+          "{attribution.Esri} &mdash; " +
+          "Source: Esri, i-cubed, USDA, USGS, AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP, UPR-EGP, and the GIS User Community",
+      },
+    },
+    WorldTerrain: {
+      options: {
+        variant: "World_Terrain_Base",
+        maxZoom: 13,
+        attribution:
+          "{attribution.Esri} &mdash; " +
+          "Source: USGS, Esri, TANA, DeLorme, and NPS",
+      },
+    },
+    WorldShadedRelief: {
+      options: {
+        variant: "World_Shaded_Relief",
+        maxZoom: 13,
+        attribution: "{attribution.Esri} &mdash; Source: Esri",
+      },
+    },
+    WorldPhysical: {
+      options: {
+        variant: "World_Physical_Map",
+        maxZoom: 8,
+        attribution:
+          "{attribution.Esri} &mdash; Source: US National Park Service",
+      },
+    },
+    OceanBasemap: {
+      options: {
+        variant: "Ocean_Basemap",
+        maxZoom: 13,
+        attribution:
+          "{attribution.Esri} &mdash; Sources: GEBCO, NOAA, CHS, OSU, UNH, CSUMB, National Geographic, DeLorme, NAVTEQ, and Esri",
+      },
+    },
+    NatGeoWorldMap: {
+      options: {
+        variant: "NatGeo_World_Map",
+        maxZoom: 16,
+        attribution:
+          "{attribution.Esri} &mdash; National Geographic, Esri, DeLorme, NAVTEQ, UNEP-WCMC, USGS, NASA, ESA, METI, NRCAN, GEBCO, NOAA, iPC",
+      },
+    },
+    WorldGrayCanvas: {
+      options: {
+        variant: "Canvas/World_Light_Gray_Base",
+        maxZoom: 16,
+        attribution: "{attribution.Esri} &mdash; Esri, DeLorme, NAVTEQ",
+      },
+    },
+  },
+} as ProviderDefinition;

--- a/providers/OpenStreetMap.ts
+++ b/providers/OpenStreetMap.ts
@@ -1,0 +1,57 @@
+import { ProviderDefinition } from ".";
+
+export default {
+  url: "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
+  options: {
+    maxZoom: 19,
+    attribution:
+      '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+  },
+  variants: {
+    Mapnik: {},
+    DE: {
+      url: "https://{s}.tile.openstreetmap.de/tiles/osmde/{z}/{x}/{y}.png",
+      options: {
+        maxZoom: 18,
+      },
+    },
+    CH: {
+      url: "https://tile.osm.ch/switzerland/{z}/{x}/{y}.png",
+      options: {
+        maxZoom: 18,
+        bounds: [
+          [45, 5],
+          [48, 11],
+        ],
+      },
+    },
+    France: {
+      url: "https://{s}.tile.openstreetmap.fr/osmfr/{z}/{x}/{y}.png",
+      options: {
+        maxZoom: 20,
+        attribution:
+          "&copy; OpenStreetMap France | {attribution.OpenStreetMap}",
+      },
+    },
+    HOT: {
+      url: "https://{s}.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png",
+      options: {
+        attribution:
+          "{attribution.OpenStreetMap}, " +
+          'Tiles style by <a href="https://www.hotosm.org/" target="_blank">Humanitarian OpenStreetMap Team</a> ' +
+          'hosted by <a href="https://openstreetmap.fr/" target="_blank">OpenStreetMap France</a>',
+      },
+    },
+    BZH: {
+      url: "https://tile.openstreetmap.bzh/br/{z}/{x}/{y}.png",
+      options: {
+        attribution:
+          '{attribution.OpenStreetMap}, Tiles courtesy of <a href="http://www.openstreetmap.bzh/" target="_blank">Breton OpenStreetMap Team</a>',
+        bounds: [
+          [46.2, -5.5],
+          [50, 0.7],
+        ],
+      },
+    },
+  },
+} as ProviderDefinition;

--- a/providers/OpenStreetMap.ts
+++ b/providers/OpenStreetMap.ts
@@ -1,11 +1,13 @@
 import { ProviderDefinition } from ".";
 
+export const attribution =
+  '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors';
+
 export default {
   url: "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
   options: {
     maxZoom: 19,
-    attribution:
-      '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+    attribution,
   },
   variants: {
     Mapnik: {},

--- a/providers/index.d.ts
+++ b/providers/index.d.ts
@@ -1,0 +1,7 @@
+import * as L from "leaflet";
+
+export type ProviderDefinition = {
+  url: string;
+  options: L.TileLayerOptions;
+  variants?: Record<string, string | Partial<ProviderDefinition>>;
+};

--- a/providers/index.d.ts
+++ b/providers/index.d.ts
@@ -1,7 +1,0 @@
-import * as L from "leaflet";
-
-export type ProviderDefinition = {
-  url: string;
-  options: L.TileLayerOptions;
-  variants?: Record<string, string | Partial<ProviderDefinition>>;
-};

--- a/providers/index.ts
+++ b/providers/index.ts
@@ -1,1 +1,14 @@
-export { default as OpenStreetMap } from "./OpenStreetMap";
+import * as L from "leaflet";
+
+export type ProviderDefinition = {
+  url: string;
+  options: L.TileLayerOptions;
+  variants?: Record<string, string | Partial<ProviderDefinition>>;
+};
+
+export { default as Esri, attribution as esriAttribution } from "./Esri";
+
+export {
+  default as OpenStreetMap,
+  attribution as osmAttribution,
+} from "./OpenStreetMap";

--- a/providers/index.ts
+++ b/providers/index.ts
@@ -1,0 +1,1 @@
+export { default as OpenStreetMap } from "./OpenStreetMap";

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -1,0 +1,3 @@
+import Provider, { OpenStreetMap } from "../index";
+
+const layer = new Provider(OpenStreetMap, "DE", { maxZoom: 42 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "noImplicitAny": true
+  }
+}


### PR DESCRIPTION
When only requiring one or two layers, leaflet-providers is overkill since it weights [22.9 kB](https://bundlephobia.com/package/leaflet-providers@1.13.0)

To improve on that I'd like to suggest/discuss:

- export provider definitions such as OpenStreetMap or Esri as separate modules
- pass one of those provider definitions in the layer constructor
- migrate to TypeScript
- use esbuild for bundling

I'm happy to hear your thoughts!