### PR TITLE
adds Swiss Federal Geoportal  map tiles

### DIFF
--- a/leaflet-providers.js
+++ b/leaflet-providers.js
@@ -1096,7 +1096,8 @@
 			options: {
 				attribution: '&copy; <a href="https://www.swisstopo.admin.ch/">swisstopo</a>',
 				minZoom: 2,
-				maxZoom: 18
+				maxZoom: 18,
+				bounds: [[45.398181, 5.140242], [48.230651, 11.47757]]
 			},
 			variants: {
 				NationalMapColor: 'ch.swisstopo.pixelkarte-farbe',

--- a/leaflet-providers.js
+++ b/leaflet-providers.js
@@ -1090,6 +1090,24 @@
 					},
 				}
 			},
+		},
+		SwissFederalGeoportal: {
+			url: 'https://wmts.geo.admin.ch/1.0.0/{variant}/default/current/3857/{z}/{x}/{y}.jpeg',
+			options: {
+				attribution: '&copy; <a href="https://www.swisstopo.admin.ch/">swisstopo</a>',
+				minZoom: 2,
+				maxZoom: 18
+			},
+			variants: {
+				NationalMapColor: 'ch.swisstopo.pixelkarte-farbe',
+				NationalMapGrey: 'ch.swisstopo.pixelkarte-grau',
+				SWISSIMAGE: {
+					options: {
+						variant: 'ch.swisstopo.swissimage',
+						maxZoom: 19
+					}
+				}
+			}
 		}
 	};
 


### PR DESCRIPTION
# adds Swiss Federal Geoportal  map tiles

This PR adds the following Swiss National maps:
- National Map Color (ch.swisstopo.pixelkarte-farbe)
- National Map Grey (ch.swisstopo.pixelkarte-grau)
- Orthophotomosaic "Swissimage" (ch.swisstopo.swissimage)

More Information:
https://www.geo.admin.ch/en/geo-services/geo-services/portrayal-services-web-mapping/web-map-tiling-services-wmts.html

Terms of use:
https://www.geo.admin.ch/en/geo-services/geo-services/terms-of-use.html
> Free acquisition and use
> The acquisition and use of data or services is free of charge, subject to the provisions on fair use.

API docs:
https://api3.geo.admin.ch/services/sdiservices.html#wmts