### PR TITLE
Update links to Azure Maps official docs

### DIFF
--- a/leaflet-providers.js
+++ b/leaflet-providers.js
@@ -1053,7 +1053,7 @@
 				'&tilesetId={variant}&x={x}&y={y}&zoom={z}&language={language}'+
 				'&subscription-key={subscriptionKey}',
 			options: {
-				attribution: 'See https://docs.microsoft.com/en-US/rest/api/maps/renderv2/getmaptilepreview for details.',
+				attribution: 'See https://docs.microsoft.com/en-us/rest/api/maps/render-v2/get-map-tile for details.',
 				apiVersion: '2.0',
 				variant: 'microsoft.imagery',
 				subscriptionKey: '<insert your subscription key here>',
@@ -1073,7 +1073,7 @@
 					'&subscription-key={subscriptionKey}',
 					options: {
 						timeStamp: '2021-05-08T09:03:00Z',
-						attribution: 'See https://docs.microsoft.com/en-US/rest/api/maps/renderv2/getmaptilepreview#uri-parameters for details.',
+						attribution: 'See https://docs.microsoft.com/en-us/rest/api/maps/render-v2/get-map-tile#uri-parameters for details.',
 						variant: 'microsoft.weather.infrared.main',
 					},
 				},
@@ -1085,7 +1085,7 @@
 					'&subscription-key={subscriptionKey}',
 					options: {
 						timeStamp: '2021-05-08T09:03:00Z',
-						attribution: 'See https://docs.microsoft.com/en-US/rest/api/maps/renderv2/getmaptilepreview#uri-parameters for details.',
+						attribution: 'See https://docs.microsoft.com/en-us/rest/api/maps/render-v2/get-map-tile#uri-parameters for details.',
 						variant: 'microsoft.weather.radar.main',
 					},
 				}


### PR DESCRIPTION
Update links to Azure Maps official docs as mentioned in https://github.com/leaflet-extras/leaflet-providers/issues/427.