### PR TITLE
Use preferred tile.openstreetmap.org URL

### DIFF
--- a/leaflet-providers.js
+++ b/leaflet-providers.js
@@ -77,7 +77,7 @@
 
 	L.TileLayer.Provider.providers = {
 		OpenStreetMap: {
-			url: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+			url: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
 			options: {
 				maxZoom: 19,
 				attribution:


### PR DESCRIPTION
Now that tile.openstreetmap.org supports HTTP/2 + HTTP/3 the old (a|b|c).tile.openstreetmap.org is no longer recommended.

Use tile.openstreetmap.org directly is faster and will likely result in a better cache hit ratio.

Signed-off-by: Grant Slater <git@firefishy.com>