### PR TITLE
build: switch from mversion to npm-version

### DIFF
--- a/.mversionrc
+++ b/.mversionrc
@@ -1,8 +1,0 @@
-{
-  "commitMessage": "Bumped version to %s",
-  "tagName": "%s",
-  "scripts": {
-  	"preupdate": "npm run min",
-  	"postupdate": "git push && git push --tags && npm publish"
-  }
-}

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
         "testsuite": "mocha-chrome tests/index.html",
         "lint": "eslint --config .eslintrc leaflet-providers.js index.html preview/*.js preview/*.html tests/*",
         "min": "uglifyjs leaflet-providers.js -mc -o leaflet-providers.min.js",
-        "release-patch": "mversion patch -m",
-        "release-minor": "mversion minor -m"
+        "preversion": "npm run min",
+        "postversion": "git push && git push --tags && npm publish"
     },
     "license": "BSD-2-Clause",
     "bugs": {
@@ -31,7 +31,6 @@
         "eslint-plugin-html": "^7.0.0",
         "mocha": "^10.0.0",
         "mocha-chrome": "^2.2.0",
-        "mversion": "^2.0.1",
         "uglify-js": "^3.14.1"
     },
     "autoupdate": {


### PR DESCRIPTION
Maybe we should add a `npm run lint` in `preversion` stage before calling `npm run min` @jieter ?