### PR TITLE
A,b,c.tile.openstreetmap.de subdomains of tile.openstreetmap.de are cancelled

### DIFF
--- a/leaflet-providers.js
+++ b/leaflet-providers.js
@@ -86,7 +86,7 @@
 			variants: {
 				Mapnik: {},
 				DE: {
-					url: 'https://{s}.tile.openstreetmap.de/{z}/{x}/{y}.png',
+					url: 'https://tile.openstreetmap.de/{z}/{x}/{y}.png',
 					options: {
 						maxZoom: 18
 					}


### PR DESCRIPTION
For more information please see in the German Forum  https://community.openstreetmap.org/t/a-b-c-tile-openstreetmap-de-subdomains-von-tile-openstreetmap-de-werden-aufgehoben/100830