### PR TITLE
Update provider url for BasemapAT to new url scheme

### DIFF
--- a/leaflet-providers.js
+++ b/leaflet-providers.js
@@ -796,11 +796,10 @@
 			}
 		},
 		BasemapAT: {
-			url: 'https://maps{s}.wien.gv.at/basemap/{variant}/{type}/google3857/{z}/{y}/{x}.{format}',
+			url: 'https://mapsneu.wien.gv.at/basemap/{variant}/{type}/google3857/{z}/{y}/{x}.{format}',
 			options: {
 				maxZoom: 19,
 				attribution: 'Datenquelle: <a href="https://www.basemap.at">basemap.at</a>',
-				subdomains: ['', '1', '2', '3', '4'],
 				type: 'normal',
 				format: 'png',
 				bounds: [[46.358770, 8.782379], [49.037872, 17.189532]],


### PR DESCRIPTION
this PR updates to the new supported scheme of urls:

see migration info here: https://cdn.basemap.at/basemap.at_URL_Umstellung_2023.pdf