### PR TITLE
Update ModisTerraChlorophyll URL

### DIFF
--- a/leaflet-providers.js
+++ b/leaflet-providers.js
@@ -966,7 +966,7 @@
 				},
 				ModisTerraChlorophyll: {
 					options: {
-						variant: 'MODIS_Terra_Chlorophyll_A',
+						variant: 'MODIS_Terra_L2_Chlorophyll_A',
 						format: 'png',
 						maxZoom: 7,
 						opacity: 0.75


### PR DESCRIPTION
Current ModisTerraChlorophyll layer is returning error 400. Changing the variant according to https://www.earthdata.nasa.gov/learn/blog/changes-chlorophyll-a-layers. 