### PR TITLE
Add Alidade Satellite style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Leaflet-providers changelog
 
+## 2.1.0 (2024-02-29)
+
+- Add Alidade Satellite from Stadia Maps [#554](https://github.com/leaflet-extras/leaflet-providers/pull/554)
+
 ## 2.0.0 (2023-08-28)
 
 - Update provider url for BasemapAT to new url scheme [#522](https://github.com/leaflet-extras/leaflet-providers/pull/522)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Leaflet-providers changelog
 
-## 2.1.0 (2024-02-29)
+## Unreleased
 
 - Add Alidade Satellite from Stadia Maps [#554](https://github.com/leaflet-extras/leaflet-providers/pull/554)
 

--- a/index.html
+++ b/index.html
@@ -53,6 +53,7 @@
 			'Stamen Watercolor': L.tileLayer.provider('Stadia.StamenWatercolor'),
 			'Stadia Alidade Smooth': L.tileLayer.provider('Stadia.AlidadeSmooth'),
 			'Stadia Alidade Smooth Dark': L.tileLayer.provider('Stadia.AlidadeSmoothDark'),
+			'Stadia Alidade Satellite': L.tileLayer.provider('Stadia.AlidadeSatellite'),
 			'Stadia Outdoors': L.tileLayer.provider('Stadia.Outdoors'),
 			'Jawg Streets': L.tileLayer.provider('Jawg.Streets'),
 			'Jawg Terrain': L.tileLayer.provider('Jawg.Terrain'),

--- a/leaflet-providers.js
+++ b/leaflet-providers.js
@@ -208,6 +208,16 @@
 			variants: {
 				AlidadeSmooth: 'alidade_smooth',
 				AlidadeSmoothDark: 'alidade_smooth_dark',
+				AlidadeSatellite: {
+					options: {
+						attribution:
+						  '&copy; CNES, Distribution Airbus DS, © Airbus DS, © PlanetObserver (Contains Copernicus Data) | ' +
+							'&copy; <a href="https://www.stadiamaps.com/" target="_blank">Stadia Maps</a> ' +
+							'&copy; <a href="https://openmaptiles.org/" target="_blank">OpenMapTiles</a> ' +
+							'{attribution.OpenStreetMap}',
+						variant: 'alidade_satellite'
+					}
+				},
 				OSMBright: 'osm_bright',
 				Outdoors: 'outdoors',
 				StamenToner: {

--- a/leaflet-providers.js
+++ b/leaflet-providers.js
@@ -215,7 +215,8 @@
 							'&copy; <a href="https://www.stadiamaps.com/" target="_blank">Stadia Maps</a> ' +
 							'&copy; <a href="https://openmaptiles.org/" target="_blank">OpenMapTiles</a> ' +
 							'{attribution.OpenStreetMap}',
-						variant: 'alidade_satellite'
+						variant: 'alidade_satellite',
+						ext: 'jpg',
 					}
 				},
 				OSMBright: 'osm_bright',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "leaflet-providers",
-    "version": "2.1.0",
+    "version": "2.0.0",
     "description": "An extension to Leaflet that contains configurations for various free tile providers.",
     "main": "leaflet-providers.js",
     "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "leaflet-providers",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "description": "An extension to Leaflet that contains configurations for various free tile providers.",
     "main": "leaflet-providers.js",
     "repository": {


### PR DESCRIPTION
Adds raster tile endpoint for Stadia Maps styles with satellite and aerial imagery.