### PR TITLE
Add tiles in Catalan

### DIFF
--- a/leaflet-providers.js
+++ b/leaflet-providers.js
@@ -124,7 +124,7 @@
 				CAT: {
 					url: 'https://tile.openstreetmap.bzh/ca/{z}/{x}/{y}.png',
 					options: {
-						attribution: '{attribution.OpenStreetMap}, Tiles courtesy of <a href="https://wiki.openstreetmap.org/wiki/Ca:Mapa_en_catal%C3%A0" target="_blank">Breton OpenStreetMap Team</a>',
+						attribution: '{attribution.OpenStreetMap}, Tiles courtesy of <a href="https://www.openstreetmap.cat" target="_blank">Breton OpenStreetMap Team</a>',
 					}
 				}
 			}

--- a/leaflet-providers.js
+++ b/leaflet-providers.js
@@ -120,7 +120,7 @@
 						attribution: '{attribution.OpenStreetMap}, Tiles courtesy of <a href="http://www.openstreetmap.bzh/" target="_blank">Breton OpenStreetMap Team</a>',
 						bounds: [[46.2, -5.5], [50, 0.7]]
 					}
-				}
+				},
 				CAT: {
 					url: 'https://tile.openstreetmap.bzh/ca/{z}/{x}/{y}.png',
 					options: {

--- a/leaflet-providers.js
+++ b/leaflet-providers.js
@@ -121,6 +121,12 @@
 						bounds: [[46.2, -5.5], [50, 0.7]]
 					}
 				}
+				CAT: {
+					url: 'https://tile.openstreetmap.bzh/ca/{z}/{x}/{y}.png',
+					options: {
+						attribution: '{attribution.OpenStreetMap}, Tiles courtesy of <a href="https://wiki.openstreetmap.org/wiki/Ca:Mapa_en_catal%C3%A0" target="_blank">Breton OpenStreetMap Team</a>',
+					}
+				}
 			}
 		},
 		MapTilesAPI: {


### PR DESCRIPTION
See the map at https://www.openstreetmap.cat. Hosted by the [Breton OpenStreetMap Team](https://www.openstreetmap.bzh).