### PR TITLE
Add scale parameter to Thunderforest url

### DIFF
--- a/leaflet-providers.js
+++ b/leaflet-providers.js
@@ -336,7 +336,7 @@
 			}
 		},
 		Thunderforest: {
-			url: 'https://{s}.tile.thunderforest.com/{variant}/{z}/{x}/{y}.png?apikey={apikey}',
+			url: 'https://{s}.tile.thunderforest.com/{variant}/{z}/{x}/{y}{r}.png?apikey={apikey}',
 			options: {
 				attribution:
 					'&copy; <a href="http://www.thunderforest.com/">Thunderforest</a>, {attribution.OpenStreetMap}',


### PR DESCRIPTION
As described in there [Tiles API](https://www.thunderforest.com/docs/map-tiles-api/), Thunderforest supports scaling.

In this PR i updated the Thunderforest url to reflect the url stated in the API by adding the scaling parameter.

Tested successfully with landscape variant