### PR TITLE
fix: update MapTiler variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Update the MapTiler variants [#591](https://github.com/leaflet-extras/leaflet-providers/pull/591)
 - Add tiles in Catalan [#562](https://github.com/leaflet-extras/leaflet-providers/pull/562)
 - Removed Esri.DeLorme layer [#556](https://github.com/leaflet-extras/leaflet-providers/pull/556)
 - Update GeoportailFrance tiles url & remove apikey parameter [571](https://github.com/leaflet-extras/leaflet-providers/pull/571)

--- a/leaflet-providers.js
+++ b/leaflet-providers.js
@@ -444,9 +444,9 @@
 				maxZoom: 21
 			},
 			variants: {
-				Streets: 'streets',
-				Basic: 'basic',
-				Bright: 'bright',
+				Streets: 'streets-v2',
+				Basic: 'basic-v2',
+				Bright: 'bright-v2',
 				Pastel: 'pastel',
 				Positron: 'positron',
 				Hybrid: {
@@ -455,12 +455,35 @@
 						ext: 'jpg'
 					}
 				},
-				Toner: 'toner',
-				Topo: 'topo',
-				Voyager: 'voyager',
+				Toner: 'toner-v2',
+				Topo: 'topo-v2',
+				Voyager: 'voyager-v2',
 				Ocean: 'ocean',
 				Backdrop: 'backdrop',
-				Dataviz: 'dataviz'
+				Dataviz: 'dataviz',
+				DatavizLight: 'dataviz-light',
+				DatavizDark: 'dataviz-dark',
+				Aquarelle: {
+					options: {
+						variant: 'aquarelle',
+						ext: 'webp'
+					}
+				},
+				Landscape: 'landscape',
+				Openstreetmap: {
+					options: {
+						variant: 'openstreetmap',
+						ext: 'jpg'
+					}
+				},
+				Outdoor: 'outdoor-v2',
+				Satellite: {
+					options: {
+						variant: 'satellite',
+						ext: 'jpg'
+					}
+				},
+				Winter: 'winter-v2',
 			}
 		},
 		TomTom: {


### PR DESCRIPTION
Hi! I would like to inform you that MapTiler has created several new variants of its maps: `streets-v2`, `basic-v2`, etc. I received this email from MapTiler yesterday:


> I wanted to reach out and inform you that “MapTiler Streets” map style you are currently using is outdated.
>
> The transition to the latest version ([Streets-v2](http://www.maptiler.com/m/r/eb0fc49c30ca5e3c3310e9cf7?ct=YTo1OntzOjY6InNvdXJjZSI7YToyOntpOjA7czo1OiJlbWFpbCI7aToxO2k6Mzk2O31zOjU6ImVtYWlsIjtpOjM5NjtzOjQ6InN0YXQiO3M6MjI6IjY2Y2M2NDNmMjkwNmM5NTM5ODQ2NjciO3M6NDoibGVhZCI7czo2OiIzMDc1MTciO3M6NzoiY2hhbm5lbCI7YToxOntzOjU6ImVtYWlsIjtpOjM5Njt9fQ%3D%3D&)) is really simple. All it takes is changing one line of code.
We prepared a clear article that will help you with the upgrade:
[Versions of map styles and how to upgrade them.](http://www.maptiler.com/m/r/71c1430ea0423977f15b69e22?ct=YTo1OntzOjY6InNvdXJjZSI7YToyOntpOjA7czo1OiJlbWFpbCI7aToxO2k6Mzk2O31zOjU6ImVtYWlsIjtpOjM5NjtzOjQ6InN0YXQiO3M6MjI6IjY2Y2M2NDNmMjkwNmM5NTM5ODQ2NjciO3M6NDoibGVhZCI7czo2OiIzMDc1MTciO3M6NzoiY2hhbm5lbCI7YToxOntzOjU6ImVtYWlsIjtpOjM5Njt9fQ%3D%3D&)
>
> Using deprecated map styles could lead to inefficiencies and errors.
> The outdated style will not be supported in the future. 
>
> Best Wishes,


I also received similar mails for other variants. As "outdated styles will not be supported in the future", I propose to update them. I also added some other variants.

The details of each variant can be checked using the URL `https://api.maptiler.com/maps/{variant}/tiles.json?key={key}`

