### PR TITLE
remove: deprecated OpenFireMap

### DIFF
--- a/leaflet-providers.js
+++ b/leaflet-providers.js
@@ -186,13 +186,6 @@
 				attribution: 'Map data: {attribution.OpenStreetMap} | Map style: &copy; <a href="https://www.OpenRailwayMap.org">OpenRailwayMap</a> (<a href="https://creativecommons.org/licenses/by-sa/3.0/">CC-BY-SA</a>)'
 			}
 		},
-		OpenFireMap: {
-			url: 'http://openfiremap.org/hytiles/{z}/{x}/{y}.png',
-			options: {
-				maxZoom: 19,
-				attribution: 'Map data: {attribution.OpenStreetMap} | Map style: &copy; <a href="http://www.openfiremap.org">OpenFireMap</a> (<a href="https://creativecommons.org/licenses/by-sa/3.0/">CC-BY-SA</a>)'
-			}
-		},
 		SafeCast: {
 			url: 'https://s3.amazonaws.com/te512.safecast.org/{z}/{x}/{y}.png',
 			options: {

--- a/preview/preview.js
+++ b/preview/preview.js
@@ -65,7 +65,6 @@
 			'^JusticeMap',
 			'OpenAIP',
 			'OpenRailwayMap',
-			'OpenFireMap',
 			'SafeCast',
 			'WaymarkedTrails.(hiking|cycling|mtb|slopes|riding|skating)'
 		];


### PR DESCRIPTION
OpenFireMap has switched to a different model and turned off the tiles. There are no plans of reviving them - https://github.com/FrnkMrz/OpenFireMapV2/issues/9#issuecomment-4182886958