### PR TITLE
updated url for JusticeMap tiles

### DIFF
--- a/leaflet-providers.js
+++ b/leaflet-providers.js
@@ -928,9 +928,10 @@
 		},
 		JusticeMap: {
 			// Justice Map (http://www.justicemap.org/)
+			// Raster map tiles migrated to (https://maptile3.org/) in 2023
 			// Visualize race and income data for your community, county and country.
 			// Includes tools for data journalists, bloggers and community activists.
-			url: 'https://www.justicemap.org/tile/{size}/{variant}/{z}/{x}/{y}.png',
+			url: 'https://maptile3.org/2020/{size}/{variant}/{z}/{x}/{y}.png',
 			options: {
 				attribution: '<a href="http://www.justicemap.org/terms.php">Justice Map</a>',
 				// one of 'county', 'tract', 'block'


### PR DESCRIPTION
The JusticeMap tiles have been broken in leaflet-providers since ~2023, when JusticeMap migrated their raster map tiles to maptile3.org. JusticeMap describes that migration [here](https://www.justicemap.org/index.php?giAdvanced=0#instruction_div).

This pull request fixes the problem by updating the JusticeMap url format in leaflet-providers.js to the maptile3.org location.

This should resolve issue https://github.com/leaflet-extras/leaflet-providers/issues/495