### PR TITLE
Update CartoDB layers to support newly required API keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Update Thunderforest layers endpoint & add Atlas layer [#690](https://github.com/leaflet-extras/leaflet-providers/pull/690)
 - Use `apiKey` instead of `app_id` for HERE [#676](https://github.com/leaflet-extras/leaflet-providers/pull/676)
 - Add new Stamen Toner variants [#671](https://github.com/leaflet-extras/leaflet-providers/pull/671)
+- Update CartoDB layers to support newly required API keys [#702](https://github.com/leaflet-extras/leaflet-providers/pull/702)
 
 ## 3.0.0 (2025-10-30)
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,17 @@ Leaflet-providers provides tile layers from different providers, including *Open
 
 In addition to the providers you are free<b id="what-is-free">1</b> to use, we support some layers which require registration.
 
+### CartoDB
+
+In order to use CartoDB layers, you must [request an API key](https://carto.com/basemaps/apikey/). Once generated, you have to add your key to `L.tileLayer.provider` in the options:
+
+```JavaScript
+L.tileLayer.provider('CartoDB.Positron', {
+    variant: '<insert map id here or blank for default variant>',
+    key: '<insert API key here>'
+}).addTo(map);
+```
+
 ### HERE
 
 In order to use HERE layers, you must [register](https://platform.here.com/portal/). Once registered, you can create an `apiKey` which you have to pass to `L.tileLayer.provider` in the options:

--- a/leaflet-providers.js
+++ b/leaflet-providers.js
@@ -740,12 +740,13 @@
 			}
 		},
 		CartoDB: {
-			url: 'https://{s}.basemaps.cartocdn.com/{variant}/{z}/{x}/{y}{r}.png',
+			url: 'https://{s}.basemaps.cartocdn.com/{variant}/{z}/{x}/{y}{r}.png?key={key}',
 			options: {
 				attribution: '{attribution.OpenStreetMap} &copy; <a href="https://carto.com/attributions">CARTO</a>',
 				subdomains: 'abcd',
 				maxZoom: 20,
-				variant: 'light_all'
+				variant: 'light_all',
+				key: '<insert your API key here>',
 			},
 			variants: {
 				Positron: 'light_all',


### PR DESCRIPTION
CartoDB started requiring API keys - https://carto.com/basemaps/apikey/

This should somehow propagate to the preview site but I am not certain how that works.

Fix: #703