### PR TITLE
Add support for vector tiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Update Thunderforest layers endpoint & add Atlas layer [#690](https://github.com/leaflet-extras/leaflet-providers/pull/690)
 - Use `apiKey` instead of `app_id` for HERE [#676](https://github.com/leaflet-extras/leaflet-providers/pull/676)
 - Add new Stamen Toner variants [#671](https://github.com/leaflet-extras/leaflet-providers/pull/671)
+- Add support for vector tiles [#706](https://github.com/leaflet-extras/leaflet-providers/pull/706)
 
 ## 3.0.0 (2025-10-30)
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ L.tileLayer.provider('TomTom', {
 
 ### Stadia Maps
 
-In order to use Stadia maps, you must [register](https://client.stadiamaps.com/signup/). Once registered, you can whitelist your domain within your account settings.
+In order to use Stadia maps (providers Stadia and StadiaVector), you must [register](https://client.stadiamaps.com/signup/). Once registered, you can whitelist your domain within your account settings.
 
 #### Stamen Design
 

--- a/README.md
+++ b/README.md
@@ -148,6 +148,16 @@ L.tileLayer.provider('TomTom', {
 
 In order to use Stadia maps (providers Stadia and StadiaVector), you must [register](https://client.stadiamaps.com/signup/). Once registered, you can whitelist your domain within your account settings.
 
+### Protomaps
+
+In order to use Protomaps vector tiles, you must [register](https://protomaps.com/). Once registered, get your API key from your dashboard, which you have to pass to `L.tileLayer.provider` in the options (or embed in the URL):
+
+```JavaScript
+L.tileLayer.provider('Protomaps.Light', {
+    apiKey: '<insert key here>'
+}).addTo(map);
+```
+
 #### Stamen Design
 
 As of July 31, 2023, Stamen's map styles are now hosted by [Stadia Maps](#stadia-maps). You can read the full

--- a/README.md
+++ b/README.md
@@ -21,6 +21,21 @@ Include `leaflet-providers.js` in your page after including Leaflet, e.g.:
 </head>
 ```
 
+### Vector tile providers (optional)
+
+Providers that use vector tiles (e.g. `OpenFreeMap`) require two additional libraries.
+Include them **before** `leaflet-providers.js`:
+
+```html
+<!-- maplibre-gl and its Leaflet adapter -->
+<link href="https://unpkg.com/maplibre-gl@5/dist/maplibre-gl.css" rel="stylesheet" />
+<script src="https://unpkg.com/maplibre-gl@5/dist/maplibre-gl.js"></script>
+<script src="https://unpkg.com/@maplibre/maplibre-gl-leaflet/leaflet-maplibre-gl.js"></script>
+```
+
+If these libraries are absent, calling `L.tileLayer.provider()` with a vector provider
+will throw a descriptive error.
+
 # Usage
 
 Leaflet-providers [providers](#providers) are referred to with a `provider[.<variant>]`-string. Let's say you want to add the nice [Watercolor](http://maps.stamen.com/#watercolor/) style from Stamen to your map, you pass `Stadia.StamenWatercolor` to the `L.tileLayer.provider`-constructor, which will return a [L.TileLayer](http://leafletjs.com/reference.html#tilelayer) instance for Stamens Watercolor tile layer.
@@ -28,6 +43,14 @@ Leaflet-providers [providers](#providers) are referred to with a `provider[.<var
 ```Javascript
 // add Stamen Watercolor to map.
 L.tileLayer.provider('Stadia.StamenWatercolor').addTo(map);
+```
+
+For vector tile providers the constructor returns an `L.MaplibreGL` layer instead,
+but the usage is identical — `.addTo(map)` works the same way:
+
+```Javascript
+// add OpenFreeMap Liberty (vector tiles) to map.
+L.tileLayer.provider('OpenFreeMap.Liberty').addTo(map);
 ```
 
 # Providers

--- a/leaflet-providers.js
+++ b/leaflet-providers.js
@@ -1166,6 +1166,21 @@
 				StamenTerrainLabels: 'stamen_terrain_labels',
 				StamenTerrainLines: 'stamen_terrain_lines'
 			}
+		},
+		Protomaps: {
+			url: 'https://api.protomaps.com/styles/v5/{variant}/en.json?key={apiKey}',
+			type: 'vector',
+			options: {
+				variant: 'light',
+				apiKey: '<insert your API key here>'
+			},
+			variants: {
+				Light: 'light',
+				Dark: 'dark',
+				White: 'white',
+				Grayscale: 'grayscale',
+				Black: 'black'
+			}
 		}
 	};
 

--- a/leaflet-providers.js
+++ b/leaflet-providers.js
@@ -63,8 +63,9 @@
 					}
 				);
 			};
-			provider.options.attribution = attributionReplacer(provider.options.attribution);
-
+			if (provider.options.attribution) {
+				provider.options.attribution = attributionReplacer(provider.options.attribution);
+			}
 			// Compute final options combining provider options with any user overrides
 			var layerOpts = L.Util.extend({}, provider.options, options);
 			L.TileLayer.prototype.initialize.call(this, provider.url, layerOpts);
@@ -1125,10 +1126,39 @@
 				Color: 'web',
 				Grey: 'web_grau'
 			}
+		},
+		OpenFreeMap: {
+			url: 'https://tiles.openfreemap.org/styles/{variant}',
+			type: 'vector',
+			options: {
+				variant: 'liberty'
+			},
+			variants: {
+				Positron: 'positron',
+				Bright: 'bright',
+				Liberty: 'liberty',
+				Dark: 'dark',
+				Fiord: 'fiord'
+			}
 		}
 	};
 
 	L.tileLayer.provider = function(provider, options) {
+		var parts = provider.split('.');
+		var providerName = parts[0];
+		var providerDef = L.TileLayer.Provider.providers[providerName];
+
+		if (providerDef && providerDef.type === 'vector') {
+			if (!L.maplibreGL) {
+				throw 'maplibre-gl-leaflet is required for vector tile providers. ' +
+				'See https://github.com/maplibre/maplibre-gl-leaflet';
+			}
+			var layer = new L.TileLayer.Provider(provider, options);
+			return L.maplibreGL({
+				style: L.Util.template(layer._url, layer.options),
+				attribution: layer.options.attribution
+			});
+		}
 		return new L.TileLayer.Provider(provider, options);
 	};
 

--- a/leaflet-providers.js
+++ b/leaflet-providers.js
@@ -1140,6 +1140,32 @@
 				Dark: 'dark',
 				Fiord: 'fiord'
 			}
+		},
+		StadiaVector: {
+			url: 'https://tiles.stadiamaps.com/styles/{variant}.json',
+			type: 'vector',
+			options: {
+				variant: 'alidade_smooth'
+			},
+			variants: {
+				AlidadeSmooth: 'alidade_smooth',
+				AlidadeSmoothDark: 'alidade_smooth_dark',
+				AlidadeSatellite: 'alidade_satellite',
+				OSMBright: 'osm_bright',
+				Outdoors: 'outdoors',
+				StamenToner: 'stamen_toner',
+				StamenTonerBackground: 'stamen_toner_background',
+				StamenTonerLines: 'stamen_toner_lines',
+				StamenTonerLabels: 'stamen_toner_labels',
+				StamenTonerLite: 'stamen_toner_lite',
+				StamenTonerDark: 'stamen_toner_dark',
+				StamenTonerBlacklite: 'stamen_toner_blacklite',
+				StamenWatercolor: 'stamen_watercolor',
+				StamenTerrain: 'stamen_terrain',
+				StamenTerrainBackground: 'stamen_terrain_background',
+				StamenTerrainLabels: 'stamen_terrain_labels',
+				StamenTerrainLines: 'stamen_terrain_lines'
+			}
 		}
 	};
 

--- a/preview/index.html
+++ b/preview/index.html
@@ -7,6 +7,9 @@
 	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 
 	<link rel="stylesheet" href="https://unpkg.com/leaflet@latest/dist/leaflet.css" />
+	<!-- Maplibre. OPTIONAL (only for vector tiles) -->
+	<link href="https://unpkg.com/maplibre-gl@5/dist/maplibre-gl.css" rel="stylesheet" />
+	<!-- /Maplibre -->
 
 	<style>
 		html {
@@ -78,6 +81,12 @@
 	<div id="map" class="map"></div>
 
 	<script src="https://unpkg.com/leaflet@latest/dist/leaflet.js"></script>
+
+	<!-- Maplibre. OPTIONAL (only for vector tiles) -->
+	<script src="https://unpkg.com/maplibre-gl@5/dist/maplibre-gl.js"></script>
+	<script src="https://unpkg.com/@maplibre/maplibre-gl-leaflet/leaflet-maplibre-gl.js"></script>
+	<!-- /Maplibre -->
+	 
 	<script src="../leaflet-providers.js"></script>
 
 	<script src="vendor/L.Control.Layers.Minimap.js"></script>

--- a/preview/index.html
+++ b/preview/index.html
@@ -21,7 +21,6 @@
 		}
 		body, #container { height: 100%; margin: 0; padding: 0;}
 		.map { height: 100%; }
-
 		#info {
 			background: rgba(255, 255, 255, 0.85);
 			box-shadow: 0 0 15px rgba(0, 0, 0, 0.2);
@@ -56,6 +55,42 @@
 			font-size: 10px;
 			overflow-x: auto;
 		}
+		.vector-icon {	
+			display: inline-block;
+			font-size: 11px;
+			vertical-align: middle;
+			margin-right: 2px;
+		}
+		.tile-type-filter-bar {
+			display: flex;
+			gap: 4px;
+			padding: 6px;
+			background: #f4f4f5;
+			border-bottom: 1px solid #e4e4e7;
+			position: sticky;
+			top: 0;
+			z-index: 1001;
+		}
+		.tile-type-btn {
+			flex: 1;
+			padding: 4px 6px;
+			font-size: 11px;
+			font-weight: 600;
+			border: 1px solid #d4d4d8;
+			border-radius: 4px;
+			background: #ffffff;
+			color: #3f3f46;
+			cursor: pointer;
+			transition: all 0.15s ease;
+		}
+		.tile-type-btn:hover {
+			background: #e4e4e7;
+		}
+		.tile-type-btn.active {
+			background: #2563eb;
+			color: #ffffff;
+			border-color: #1d4ed8;
+		}
 	</style>
 	<!--Fork Me on Github ribbon, we're using the awesome version from simonwhitaker available at https://github.com/simonwhitaker/github-fork-ribbon-css  -->
 	<link rel="stylesheet" href="../css/gh-fork-ribbon.css" />
@@ -86,7 +121,7 @@
 	<script src="https://unpkg.com/maplibre-gl@5/dist/maplibre-gl.js"></script>
 	<script src="https://unpkg.com/@maplibre/maplibre-gl-leaflet/leaflet-maplibre-gl.js"></script>
 	<!-- /Maplibre -->
-	 
+
 	<script src="../leaflet-providers.js"></script>
 
 	<script src="vendor/L.Control.Layers.Minimap.js"></script>

--- a/preview/preview.js
+++ b/preview/preview.js
@@ -184,10 +184,17 @@
 			var pre = L.DomUtil.create('pre', null, container);
 			var code = L.DomUtil.create('code', 'javascript', pre);
 
+			var depsVectorHeading = L.DomUtil.create('h4', '', container);
+			var depsVectorP = L.DomUtil.create('p', '', container);
+			var depsVectorPre = L.DomUtil.create('pre', '', container);
+			var depsVectorCode = L.DomUtil.create('code', '', depsVectorPre);
+			depsVectorHeading.style.display = depsVectorP.style.display = depsVectorPre.style.display = 'none';
+
 			var update = function(event) {
 				code.innerHTML = '';
 
 				var names = [];
+				var depsVector = null;
 
 				// loop over the layers in the map and add the JS
 				for (var key in map._layers) {
@@ -204,8 +211,28 @@
 						name: layer._providerName
 					}));
 					code.innerHTML += layer.getExampleJS();
+					if (layer._depsVector) {
+						depsVector = layer._depsVector;
+					}
 				}
 				providerNames.innerHTML = names.join(', ');
+
+				// Show / hide the extra dependencies warning section
+				if (depsVector) {
+					var depLinks = depsVector.map(function (d) {
+						return '<a href="' + d.url + '" target="_blank">' + d.name + '</a>';
+					}).join(' and ');
+					depsVectorHeading.innerHTML = '⚠ Extra dependencies required';
+					depsVectorP.innerHTML = 'This provider uses vector tiles and requires ' + depLinks + '.' +
+						' Include these <strong>before</strong> <code>leaflet-providers.js</code>:';
+					depsVectorCode.innerHTML =
+						'&lt;link href="https://unpkg.com/maplibre-gl@5/dist/maplibre-gl.css" rel="stylesheet" /&gt;\n' +
+						'&lt;script src="https://unpkg.com/maplibre-gl@5/dist/maplibre-gl.js"&gt;&lt;/script&gt;\n' +
+						'&lt;script src="https://unpkg.com/@maplibre/maplibre-gl-leaflet/leaflet-maplibre-gl.js"&gt;&lt;/script&gt;';
+					depsVectorHeading.style.display = depsVectorP.style.display = depsVectorPre.style.display = '';
+				} else {
+					depsVectorHeading.style.display = depsVectorP.style.display = depsVectorPre.style.display = 'none';
+				}
 
 				/* global hljs:true */
 				hljs.highlightBlock(code);

--- a/preview/preview.js
+++ b/preview/preview.js
@@ -115,23 +115,104 @@
 
 	// Pass a filter in the hash tag to show only layers containing that string
 	// for example: #filter=Open
-	var filterLayersControl = function() {
-		var hash = window.location.hash;
-		var filterIndex = hash.indexOf('filter=');
-		if (filterIndex !== -1) {
-			var filterString = hash.substr(filterIndex + 7).trim();
-			var visible = layersControl.filter(filterString);
+	// Add vector/raster filter selector at the top of the right sidebar control
+	var controlContainer = layersControl.getContainer();
+	var filterBar = L.DomUtil.create('div', 'tile-type-filter-bar', controlContainer);
+	controlContainer.insertBefore(filterBar, controlContainer.firstChild);
 
+	var filterOptions = [
+		{ label: 'All', value: 'all' },
+		{ label: '📐 Vector', value: 'vector' },
+		{ label: '🗺️ Raster', value: 'raster' }
+	];
+
+	var currentTileType = 'all';
+
+	var getSearchOrHashFilterString = function () {
+		var str = window.location.search + window.location.hash;
+		var filterIndex = str.indexOf('filter=');
+		if (filterIndex !== -1) {
+			var filterVal = str.substr(filterIndex + 7);
+			var ampersandIndex = filterVal.indexOf('&');
+			if (ampersandIndex !== -1) {
+				filterVal = filterVal.substring(0, ampersandIndex);
+			}
+			return decodeURIComponent(filterVal).trim();
+		}
+		return '';
+	};
+
+	var filterByTileType = function (type) {
+		currentTileType = type || currentTileType;
+		var searchString = getSearchOrHashFilterString();
+		var visibleLayers = {};
+
+		var labels = controlContainer.querySelectorAll('label.leaflet-minimap-container');
+		for (var i = 0; i < labels.length; i++) {
+			var label = labels[i];
+			var name = label._layerName || '';
+			var providerName = name.split('.')[0];
+			var providerDef = L.TileLayer.Provider && L.TileLayer.Provider.providers && L.TileLayer.Provider.providers[providerName];
+			var isVector = (providerDef && providerDef.type === 'vector');
+
+			var typeMatch = (currentTileType === 'all') || (currentTileType === 'vector' && isVector) || (currentTileType === 'raster' && !isVector);
+			var searchMatch = (searchString === '') || (name.indexOf(searchString) !== -1);
+
+			if (typeMatch && searchMatch) {
+				L.DomUtil.removeClass(label, 'leaflet-minimap-hidden');
+				visibleLayers[name] = true;
+			} else {
+				L.DomUtil.addClass(label, 'leaflet-minimap-hidden');
+			}
+		}
+		return visibleLayers;
+	};
+
+	filterOptions.forEach(function (opt, idx) {
+		var btn = L.DomUtil.create('button', 'tile-type-btn' + (idx === 0 ? ' active' : ''), filterBar);
+		btn.innerHTML = opt.label;
+		btn.type = 'button';
+		L.DomEvent.on(btn, 'click', function (e) {
+			L.DomEvent.stopPropagation(e);
+			var buttons = filterBar.querySelectorAll('.tile-type-btn');
+			for (var i = 0; i < buttons.length; i++) {
+				L.DomUtil.removeClass(buttons[i], 'active');
+			}
+			L.DomUtil.addClass(btn, 'active');
+			filterByTileType(opt.value);
+		});
+	});
+
+	// Annotate vector layer items in the sidebar with the 📐 icon without modifying vendor code
+	var labels = controlContainer.querySelectorAll('label.leaflet-minimap-container');
+	for (var i = 0; i < labels.length; i++) {
+		var lbl = labels[i];
+		var name = lbl._layerName || '';
+		var providerName = name.split('.')[0];
+		var providerDef = L.TileLayer.Provider && L.TileLayer.Provider.providers && L.TileLayer.Provider.providers[providerName];
+		if (providerDef && providerDef.type === 'vector') {
+			var span = lbl.querySelector('.leaflet-minimap-label span:last-child');
+			if (span && span.innerHTML.indexOf('vector-icon') === -1) {
+				span.innerHTML = ' <span class="vector-icon" title="Vector Tiles">📐</span>' + span.innerHTML;
+			}
+		}
+	}
+
+	var filterLayersControl = function () {
+		var visible = filterByTileType();
+		var searchString = getSearchOrHashFilterString();
+
+		if (searchString !== '') {
 			// enable first layer as actual layer.
 			var first = Object.keys(visible)[0];
-			if (first in baseLayers) {
+			if (first && first in baseLayers) {
 				map.addLayer(baseLayers[first]);
-				map.eachLayer(function(layer) {
+				map.eachLayer(function (layer) {
 					if (layer._providerName !== first) {
 						map.removeLayer(layer);
 					}
 				});
-				layersControl.filter(filterString);
+				filterByTileType();
 			}
 		}
 	};
@@ -152,6 +233,16 @@
 	// current view, move the map view to contain the bounds
 	map.on('baselayerchange', function(e) {
 		var layer = e.layer;
+
+		// Remove any other base layer currently on the map
+		for (var name in baseLayers) {
+			var baseLayer = baseLayers[name];
+			if (baseLayer !== layer && map.hasLayer(baseLayer)) {
+				map.removeLayer(baseLayer);
+			}
+		}
+
+		
 		if (!map.hasLayer(layer)) {
 			return;
 		}

--- a/preview/shared.js
+++ b/preview/shared.js
@@ -60,6 +60,50 @@ L.tileLayer.provider.eachLayer = function(callback) {
 	}
 };
 
+// Wrap the factory so every returned layer has the preview metadata that
+// preview.js relies on (_providerName, getExampleJS). For L.TileLayer.Provider
+// instances, _providerName is already set by the monkeypatched initialize above;
+// for vector layers (L.MaplibreGL) that bypass that class, we set them here.
+var origFactory = L.tileLayer.provider;
+L.tileLayer.provider = function (name, options) {
+	var layer = origFactory(name, options);
+	if (!layer._providerName) {
+		layer._providerName = name;
+		// Mark that this layer type needs extra dependencies beyond Leaflet.
+		layer._depsVector = [
+			{ name: 'maplibre-gl', url: 'https://maplibre.org/maplibre-gl-js/' },
+			{ name: 'maplibre-gl-leaflet', url: 'https://github.com/maplibre/maplibre-gl-leaflet' }
+		];
+	}
+	if (!layer.getExampleJS) {
+		layer.getExampleJS = function () {
+			var layerName = name.replace('.', '_');
+
+			// Create a provider instance to resolve the template URL & attribution
+			var providerInstance = new L.TileLayer.Provider(name);
+			var exampleCodes = providerInstance._exampleAPIcodes || {};
+			var opts = L.extend({}, providerInstance.options, exampleCodes);
+			var styleUrl = L.Util.template(providerInstance._url, opts);
+
+			var code = 'var ' + layerName + ' = L.maplibreGL({\n';
+			code += '\tstyle: \'' + styleUrl + '\'';
+			if (providerInstance.options.attribution) {
+				var attr = providerInstance.options.attribution
+					.replace(/&/g, '&amp;')
+					.replace(/</g, '&lt;')
+					.replace(/>/g, '&gt;')
+					.replace(/"/g, '&quot;')
+					.replace(/'/g, '&#039;');
+				code += ',\n\tattribution: \'' + attr + '\'';
+			}
+			code += '\n});\n';
+			return code;
+		};
+	}
+	return layer;
+};
+L.tileLayer.provider.eachLayer = origFactory.eachLayer;
+
 if (!String.prototype.startsWith) {
 	String.prototype.startsWith = function(searchString, position) {
 		position = position || 0;

--- a/preview/vendor/L.Control.Layers.Minimap.js
+++ b/preview/vendor/L.Control.Layers.Minimap.js
@@ -305,6 +305,9 @@ function cloneLayer (layer) {
     if (layer instanceof L.LayerGroup) {
         return L.layerGroup(cloneInnerLayers(layer));
     }
+    if (L.MaplibreGL && layer instanceof L.MaplibreGL) { // MaplibreGL vector tile layer
+        return L.maplibreGL(cloneOptions(layer.options));
+    }
 
     throw 'Unknown layer, cannot clone this layer. Leaflet-version: ' + L.version;
 }


### PR DESCRIPTION
Implementation for #705, with the following features:
- `leaflet-providers.js` extended to support vector tiles
- `leaflet-providers.js` extended with vector tiles providers: OpenFreeMap, Stadia, Protomaps
- preview adapted to support vector tiles (including warning for vector tiles extra dependencies, and filters for raster and vector tiles)